### PR TITLE
Release: v0.1.0b2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [0.1.0b2] — 2026-05-28
+
+### Added
+
+- CUDA kernel for tensor product backward (trailing channels). This kernel loads output
+  cotangents only once to compute both input cotangents via two tensor product operations.
+- JAX primitive `e3j.ops.tensor_product_bwd()` with AD rules, vmap and sharding support.
+  The double backward rule is expressed in terms of one `tensor_product_bwd()` call and
+  two `tensor_product()` calls, providing infinite differentiability.
+
+### Changed
+
+- Dropped leftover `unroll` parameters that could be passed from the Python side. They
+  are now private to the CUDA side and inferred alongside kernel launch configuration.
+
 ## [0.1.0b1] — 2026-05-21
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ docs:
 # Force re-build of cuda bindings with uv and CMake
 
 uv:
-	uv sync --group cuda13_local --extra ops --group exp\
+	uv sync --group cuda13_local --extra ops\
 		--reinstall-package e3j_ops\
 		--reinstall-package e3j
 

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,9 @@ docs:
 # Force re-build of cuda bindings with uv and CMake
 
 uv:
-	uv sync --reinstall
+	uv sync --group cuda13_local --extra ops --group exp\
+		--reinstall-package e3j_ops\
+		--reinstall-package e3j
 
 # Build the python bindings `e3j_ops.xxx.so` [2]
 

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,8 @@ FFI_OBJ = bin/e3j_ops.cpp.o
 
 CU_TEST = \
 	test_scatter_add\
-	test_tensor_product
+	test_tensor_product\
+	test_tensor_product_bwd
 
 TENSOR_PRODUCT_OBJ = \
 	bin/tensor_product.cu.o
@@ -115,6 +116,11 @@ bin/%.cu.o: $(SRC_DIR)/cuda/%.cu
 
 bin/test_tensor_product:\
 	$(SRC_DIR)/tests/test_tensor_product.cpp bin/tensor_product.a
+
+	g++ $^ -o $@ -I $(INC_DIR) $(CUDA_INC_DIR) $(CUDA_LIB_DIR) $(CUDA_LINK_LIBS)
+
+bin/test_tensor_product_bwd:\
+	$(SRC_DIR)/tests/test_tensor_product_bwd.cpp bin/tensor_product_bwd.cu.o bin/tensor_product.a
 
 	g++ $^ -o $@ -I $(INC_DIR) $(CUDA_INC_DIR) $(CUDA_LIB_DIR) $(CUDA_LINK_LIBS)
 

--- a/lib/e3j_ops/CMakeLists.txt
+++ b/lib/e3j_ops/CMakeLists.txt
@@ -26,6 +26,7 @@ Python_add_library(e3j_ops MODULE WITH_SOABI
     ffi/e3j_ops.cpp
     cuda/scatter_add.cu
     cuda/tensor_product.cu
+    cuda/tensor_product_bwd.cu
     cuda/fill.cu)
 
 target_link_libraries(e3j_ops PRIVATE

--- a/lib/e3j_ops/CMakeLists.txt
+++ b/lib/e3j_ops/CMakeLists.txt
@@ -7,7 +7,8 @@ project(e3j
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --threads 4 -Xcompiler -Wall -ldl --expt-relaxed-constexpr -O3 -DNDEBUG -O3 \
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --threads 4 -Xcompiler -w \
+    -ldl --expt-relaxed-constexpr -O3 -DNDEBUG -O3 \
     -arch=sm_90\
     -gencode=arch=compute_90,code=sm_90\
     -gencode=arch=compute_90a,code=sm_90a\
@@ -37,5 +38,8 @@ target_link_libraries(e3j_ops PRIVATE
     pthread
     dl
     cudart)
+
+
+target_compile_options(e3j_ops PRIVATE -w)
 
 install(TARGETS e3j_ops DESTINATION .)

--- a/lib/e3j_ops/cuda/tensor_product/launch_trailing.cuh
+++ b/lib/e3j_ops/cuda/tensor_product/launch_trailing.cuh
@@ -18,7 +18,7 @@
 
 #include "cuda/tensor_product/trailing_channels.cuh"
 
-#define MAX_BLOCK_SIZE 512
+#define MAX_BLOCK_SIZE 256
 
 namespace e3j {
 namespace tensor_product {

--- a/lib/e3j_ops/cuda/tensor_product/launch_trailing.cuh
+++ b/lib/e3j_ops/cuda/tensor_product/launch_trailing.cuh
@@ -18,6 +18,8 @@
 
 #include "cuda/tensor_product/trailing_channels.cuh"
 
+#define MAX_BLOCK_SIZE 512
+
 namespace e3j {
 namespace tensor_product {
 
@@ -59,7 +61,7 @@ struct LaunchConfig {
         // With Mode::INNER, partial warp-wide sums accumulated in SMEM.
         if constexpr (kMode == Mode::INNER)
             sizeSMEM += sizeof(Val) * p.num_out * (1 + (p.channels_x - 1) / (32 * N));
-        if (BUFFER_COEFS_IN_SMEM) {
+        if (BUFFER_FWD_COEFS_IN_SMEM) {
             // Pad coef buffer to N-float boundary (same as kernel pointer logic).
             size_t align = N * sizeof(Val);
             sizeSMEM += (sizeCoef + align - 1) & ~(align - 1);
@@ -129,7 +131,7 @@ struct LaunchConfig {
         unsigned int threadsY = 1;
         while (
             maxBlocks * threadsX * threadsY < 2048
-            and threadsX * threadsY < 1024
+            and threadsX * threadsY < MAX_BLOCK_SIZE
             and threadsY <=  (unsigned int)p.num_out / 2
         ) {
             threadsY *= 2;
@@ -292,8 +294,5 @@ e3j::Error launch(
 
 }// namespace tensor_product
 }// namespace e3j
-
-// Defined in trailing_channels.cuh, used by both kernel and launch code.
-#undef BUFFER_COEFS_IN_SMEM
 
 #endif // _E3J_TENSOR_PRODUCT_LAUNCH_TRAILING_H_

--- a/lib/e3j_ops/cuda/tensor_product/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product/trailing_channels.cuh
@@ -22,7 +22,7 @@
 #include "cuda/array.cuh"
 
 #define WARP_MASK 0xffffffff
-#define BUFFER_COEFS_IN_SMEM true
+#define BUFFER_FWD_COEFS_IN_SMEM true
 
 namespace e3j {
 namespace tensor_product {
@@ -391,7 +391,7 @@ __global__ void kernel(
     Buffers smem = Buffers::init(x, y, z, unroll);
 
     // Optionally store coefficients in shared memory.
-    if (BUFFER_COEFS_IN_SMEM) {
+    if (BUFFER_FWD_COEFS_IN_SMEM) {
         Coef* smem_coef = reinterpret_cast<Coef*>(smem_);
         copy_pipe<1>(smem_coef, coef, num_coef);
         // Overwrite reference to GMEM `coef` with SMEM buffer.

--- a/lib/e3j_ops/cuda/tensor_product_bwd.cu
+++ b/lib/e3j_ops/cuda/tensor_product_bwd.cu
@@ -1,0 +1,133 @@
+#include "cuda/tensor_product.cuh"
+#include "cuda/tensor_product_bwd.cuh"
+#include "cuda/tensor_product_bwd/trailing_channels.cuh"
+#include "cuda/tensor_product_bwd/launch_trailing.cuh"
+
+#include "cuda/dispatch_macros.h"
+#include "ffi/error.h"
+
+
+namespace e3j {
+namespace tensor_product {
+
+namespace trailing_channels {
+
+template <typename Idx, typename Val>
+e3j::Error launch_bwd(
+    const Coef<Idx, Val> *coef,
+    const Val *x,
+    const Val *y,
+    const Val *z,
+    Val *dx,
+    Val *dy,
+    Params p,
+    cudaStream_t stream,
+    int debug
+) {
+    ModeBwd mode = GetModeBwd(
+        p.mode, p.channels_x, p.channels_y
+    );
+    #define DISPATCH_MODE_PAIR(MODE_LHS, MODE_RHS)       \
+    return launch_bwd<Idx, Val, MODE_LHS, MODE_RHS>(     \
+        coef, x, y, z, dx, dy, p, stream, debug          \
+    );
+
+    #define DISPATCH_MODE_PAIR_ERROR(MODE_LHS, MODE_RHS) \
+    return e3j::Error::InvalidArgument("incompatible modes");
+
+    __DISPATCH_MODE_PAIR(mode.lhs, mode.rhs)
+    #undef DISPATCH_MODE_PAIR
+};
+
+
+/* Specialize template for dtype pairs and mode using X macro. */
+
+#define FOR_EACH_DTYPE_PAIR(Idx, Val)               \
+template e3j::Error launch_bwd<Idx, Val>(           \
+    const Coef<Idx, Val> *coef,                     \
+    const Val *x,                                   \
+    const Val *y,                                   \
+    const Val *z,                                   \
+    Val *dx,                                        \
+    Val *dy,                                        \
+    Params p,                                       \
+    cudaStream_t stream,                            \
+    int debug                                       \
+);
+__FOR_EACH_DTYPE_PAIR
+#undef FOR_EACH_DTYPE_PAIR
+
+
+} // namespace trailing_channels
+
+
+ModeBwd GetModeBwd (Mode fwd, int channels_lhs, int channels_rhs) {
+    switch(fwd) {
+        case Mode::OUTER:
+            if (channels_lhs == 1) {          /* (1, v) -> v */
+                return {Mode::INNER, Mode::OUTER};
+            } else if (channels_rhs == 1) {   /* (u, 1) -> u */
+                return {Mode::OUTER, Mode::INNER};
+            } else {
+                printf("ERROR: Cannot backpropagate Mode::OUTER"
+                       "if both inputs have multiple channels.");
+                exit(1);
+            }
+            break;
+        case Mode::INNER:   /* (u, u) -> 1 */
+            return {Mode::OUTER, Mode::OUTER};
+            break;
+        case Mode::MAP:     /* (u, u) -> u */
+            return {Mode::MAP, Mode::MAP};
+            break;
+        default:
+            printf("ERROR: could not parse backward mode.");
+            exit(1);
+    }
+}
+
+ParamsBwd GetParamsBwd(Params p) {
+    ModeBwd mode_bwd = GetModeBwd(
+        p.mode, p.channels_x, p.channels_y
+    );
+
+    Params p_dx = {
+        .num_rows = p.num_rows,
+        .num_idx = p.num_idx,
+        .num_x = p.num_out,
+        .num_y = p.num_y,
+        .num_out = p.num_x,
+        .channels_x = p.channels_out(),
+        .channels_y = p.channels_y,
+        .mode = mode_bwd.lhs,
+        .unroll_x = p.channels_out(),
+        .unroll_y = p.channels_y,
+        .unroll_z = 0, // PLACEHOLDER
+        .layout = Layout::TRAILING_CHANNELS,
+    };
+
+    Params p_dy = {
+        .num_rows = p.num_rows,
+        .num_idx = p.num_idx,
+        .num_x = p.num_out,
+        .num_y = p.num_x,
+        .num_out = p.num_y,
+        .channels_x = p.channels_out(),
+        .channels_y = p.channels_x,
+        .mode = mode_bwd.rhs,
+        .unroll_x = p.channels_out(),
+        .unroll_y = p.channels_x,
+        .unroll_z = 0, // PLACEHOLDER
+        .layout = Layout::TRAILING_CHANNELS,
+    };
+
+    return ParamsBwd({
+        .lhs = p_dx,
+        .rhs = p_dy
+    });
+
+}
+
+
+} // namespace tensor_product
+} // namespace e3j

--- a/lib/e3j_ops/cuda/tensor_product_bwd.cu
+++ b/lib/e3j_ops/cuda/tensor_product_bwd.cu
@@ -1,3 +1,18 @@
+/* Copyright (c) 2026 InstaDeep Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "cuda/tensor_product.cuh"
 #include "cuda/tensor_product_bwd.cuh"
 #include "cuda/tensor_product_bwd/trailing_channels.cuh"

--- a/lib/e3j_ops/cuda/tensor_product_bwd.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd.cuh
@@ -1,3 +1,18 @@
+/* Copyright (c) 2026 InstaDeep Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _E3J_TENSOR_PRODUCT_BWD_H_
 #define _E3J_TENSOR_PRODUCT_BWD_H_
 

--- a/lib/e3j_ops/cuda/tensor_product_bwd.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd.cuh
@@ -1,0 +1,63 @@
+#ifndef _E3J_TENSOR_PRODUCT_BWD_H_
+#define _E3J_TENSOR_PRODUCT_BWD_H_
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include "cuda/tensor_product.cuh"
+#include "ffi/error.h"
+#include <iostream>
+
+namespace e3j {
+namespace tensor_product {
+
+namespace trailing_channels {
+
+template<typename Idx, typename Val, Mode kxMode, Mode kyMode>
+e3j::Error launch_bwd(
+    const Coef<Idx, Val> *coef,
+    const Val *x,
+    const Val *y,
+    const Val *dz,
+    Val *dx,
+    Val *dy,
+    const Params p,
+    cudaStream_t stream,
+    int debug
+);
+
+template<typename Idx, typename Val>
+e3j::Error launch_bwd(
+    const Coef<Idx, Val> *coef,
+    const Val *x,
+    const Val *y,
+    const Val *dz,
+    Val *dx,
+    Val *dy,
+    const Params p,
+    cudaStream_t stream,
+    int debug
+);
+
+}// namespace trailing_channels
+
+struct ModeBwd {
+    Mode lhs;
+    Mode rhs;
+};
+
+struct ParamsBwd {
+    Params lhs;
+    Params rhs;
+};
+
+// Infer modes of codifferential on dx and dy
+ModeBwd GetModeBwd (Mode fwd, int channels_lhs, int channels_rhs);
+
+// Infer params of codifferential on dx and dy
+ParamsBwd GetParamsBwd(Params p);
+
+
+} // namespace tensor_product
+} // namespace e3j
+
+#endif // _E3J_TENSOR_PRODUCT_BWD_H_

--- a/lib/e3j_ops/cuda/tensor_product_bwd/launch_trailing.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/launch_trailing.cuh
@@ -1,3 +1,18 @@
+/* Copyright (c) 2026 InstaDeep Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _E3J_TENSOR_PRODUCT_BWD_LAUNCH_TRAILING_H_
 #define _E3J_TENSOR_PRODUCT_BWD_LAUNCH_TRAILING_H_
 

--- a/lib/e3j_ops/cuda/tensor_product_bwd/launch_trailing.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/launch_trailing.cuh
@@ -1,0 +1,241 @@
+#ifndef _E3J_TENSOR_PRODUCT_BWD_LAUNCH_TRAILING_H_
+#define _E3J_TENSOR_PRODUCT_BWD_LAUNCH_TRAILING_H_
+
+#include "cuda/tensor_product/launch_trailing.cuh"
+#include "cuda/tensor_product_bwd/trailing_channels.cuh"
+
+namespace e3j {
+namespace tensor_product {
+namespace trailing_channels {
+
+
+template<typename Idx, typename Val, Mode kxMode, Mode kyMode>
+struct LaunchConfigBwd {
+
+    dim3 gridDim;
+    dim3 blockDim;
+    size_t sizeSMEM;
+    e3j::Error error = e3j::Error::Success();
+    int N;
+
+    static Sizes get_sizes(Params p, dim3 blockDims, int N, bool fused=true) {
+
+        constexpr int A = 16 / sizeof(Val);
+
+        int channels_z = p.channels_out();
+        // Pad allocations to N-element boundary to match to_shared() alignment.
+        int size_x_raw = p.num_x * min((int)blockDims.x * N, p.channels_x),
+            size_y_raw = p.num_y * min((int)blockDims.x * N, p.channels_y),
+            size_z_raw = p.num_out * min((int)blockDims.x * N, channels_z);
+        int size_x = (size_x_raw + (A-1)) & ~(A-1),
+            size_y = (size_y_raw + (A-1)) & ~(A-1),
+            size_z = (size_z_raw + (A-1)) & ~(A-1);
+
+        size_t sizeCoef = sizeof(Coef<Idx,Val>) * 2 * p.num_idx;
+        size_t align = N * sizeof(Val);
+        sizeCoef = (sizeCoef + align - 1) & ~(align - 1);
+        size_t sizeLoad = fused
+            ? sizeof(Val) * (size_z + size_x + size_y)
+            : sizeof(Val) * (size_z + max(size_x, size_y));
+        size_t sizeSMEM = sizeLoad;
+        // Allocate scratch SMEM space for INNER backward passes.
+        if (p.mode == Mode::OUTER and p.channels_x == 1) {
+            sizeSMEM += sizeof(Val) * p.num_x * (1 + (p.channels_y - 1) / (32 * N));
+        } else if (p.mode == Mode::OUTER and p.channels_y == 1) {
+            sizeSMEM += sizeof(Val) * p.num_y * (1 + (p.channels_x - 1) / (32 * N));
+        }
+        if (BUFFER_BWD_COEFS_IN_SMEM)
+            sizeSMEM += sizeCoef;
+
+        return Sizes {
+            .coef = sizeCoef,
+            .load = sizeLoad,
+            .smem = sizeSMEM
+        };
+
+    }
+
+    // Select the largest N ∈ {1,2,4} such that channels_z / N >= 32.
+    //
+    // Assumes LHS operand `x` carries channel content, and ensures
+    // N divides `p.channels_x`.
+    static int get_vectorization(Params p) {
+        int ch = p.channels_z();
+        if (ch / 4 >= 32 && p.channels_x % 4 == 0) {
+            return 4;
+        } else if (ch / 2 >= 32 && p.channels_x % 2 == 0) {
+            return 2;
+        } else {
+            return 1;
+        }
+    }
+
+    static LaunchConfigBwd get_hints(Params p, int debug, int N=-1) {
+
+        // SMEM : [ kz * num_z | kx * num_x or ky * num_y ]
+
+        // Query device properties for SMEM bounds.
+        DeviceProperties device = DeviceProperties::query();
+
+        // Best possible vectorization given channel dimensions
+        bool find_N = (N == -1);
+        if (find_N)
+            N = get_vectorization(p);
+
+        ParamsBwd p_bwd = GetParamsBwd(p);
+        using CfgLHS = LaunchConfig<Idx, Val, kxMode>;
+        using CfgRHS = LaunchConfig<Idx, Val, kyMode>;
+        CfgLHS cfg_lhs = CfgLHS::get_hints(p_bwd.lhs, 0, -1);
+        CfgRHS cfg_rhs = CfgRHS::get_hints(p_bwd.rhs, 0, -1);
+
+        dim3 grid = {
+            min(p.num_rows, 8192),
+            1,
+            1
+        };
+
+        dim3 block = {
+            min(cfg_lhs.blockDim.x, cfg_rhs.blockDim.x),
+            min(cfg_lhs.blockDim.y, cfg_rhs.blockDim.y),
+            1
+        };
+
+        if (find_N)
+            N = min(cfg_lhs.N, cfg_rhs.N);
+
+        Sizes sizes = get_sizes(p, block, N);
+
+        LaunchConfigBwd cfg {
+            .gridDim = grid,
+            .blockDim = block,
+            .sizeSMEM = sizes.smem,
+            .N = N,
+        };
+
+
+        cfg.log(sizes, p, debug);
+        cfg.validate(sizes, device, debug);
+        return cfg;
+    }
+
+    void validate(Sizes sizes, DeviceProperties device, int debug) {
+        switch(N) {
+            case 4:
+                return validate<4>(sizes, device, debug); break;
+            case 2:
+                return validate<2>(sizes, device, debug);
+            default:
+                return validate<1>(sizes, device, debug);
+        }
+    }
+
+    template<int N>
+    void validate(Sizes sizes, DeviceProperties device, int debug) {
+
+        if (sizes.smem >= device.smem_max) {
+            std::string msg =
+                "e3j_ops.tensor_product: SMEM overflow ("
+                + std::to_string(sizes.smem) + " B >= "
+                + std::to_string(device.smem_max) + " B max)";
+            error = e3j::Error::InvalidArgument(msg);
+        } else if (sizes.smem > device.smem_opt_in) {
+            if (debug > 0)
+                printf("WARNING: opting in to %zu B > %d B shared memory",
+                        sizes.smem, device.smem_opt_in);
+            cudaFuncSetAttribute(
+                kernel_bwd<Idx, Val, kxMode, kyMode, N>,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                device.smem_max
+            );
+        }
+    }
+
+    void log (Sizes sizes, Params p, int debug) {
+        if (debug > 1) {
+            printf("> e3j::tensor_product::kernel_bwd<<<%dx%d,%dx%d>>> N=%d\n"
+                   "\t sizeSMEM: %zu B\n"
+                   "\t sizeCoef: %zu B\n"
+                   "\t sizeLoad: %zu B\n"
+                   "\t num_idx: %d\n"
+                   "\t mode: %d\n"
+                   "\t dims: (%d, %d) -> %d\n"
+                   "\t channels: (%d, %d)\n",
+                    gridDim.x, gridDim.y, blockDim.x, blockDim.y, N,
+                    sizes.smem, sizes.coef, sizes.load,
+                    p.num_idx, p.mode, p.num_x, p.num_y, p.num_out,
+                    p.channels_x, p.channels_y
+            );
+        }
+    }
+
+};
+
+
+template<typename Idx, typename Val, Mode kxMode, Mode kyMode>
+e3j::Error launch_bwd(
+    const Coef<Idx, Val> *coef,
+    const Val *gmem_x,
+    const Val *gmem_y,
+    const Val *gmem_dz,
+    Val *gmem_dx,
+    Val *gmem_dy,
+    Params p,
+    cudaStream_t stream,
+    int debug
+) {
+
+    // Determine backward modes on LHS and RHS (rotates channel arguments)
+    using LaunchConfigBwd = LaunchConfigBwd<Idx,Val,kxMode, kyMode>;
+    LaunchConfigBwd cfg = LaunchConfigBwd::get_hints(p, debug);
+    if (cfg.error.failure())
+        return cfg.error;
+
+    int channels_z = p.channels_out();
+
+    // Number of channels processed per block: (blockDim.x * N), capped
+    // by the total channel count. Used as SMEM buffer width in BuffersBwd.
+    dim3 unroll = {
+        (unsigned int)min((int)cfg.blockDim.x * cfg.N, p.channels_x),
+        (unsigned int)min((int)cfg.blockDim.x * cfg.N, p.channels_y),
+        (unsigned int)min((int)cfg.blockDim.x * cfg.N, p.channels_out()),
+    };
+
+    CuArray2D<const Val> x  = { gmem_x,  p.num_x,   p.channels_x     };
+    CuArray2D<const Val> y  = { gmem_y,  p.num_y,   p.channels_y     };
+    CuArray2D<const Val> dz = { gmem_dz, p.num_out, p.channels_out() };
+    CuArray2D<Val>       dx = { gmem_dx, p.num_x,   p.channels_x     };
+    CuArray2D<Val>       dy = { gmem_dy, p.num_y,   p.channels_y     };
+
+    #define LAUNCH_BWD(N)                                               \
+    kernel_bwd<Idx,Val,kxMode,kyMode,N>                                 \
+        <<<cfg.gridDim, cfg.blockDim, cfg.sizeSMEM, stream>>>           \
+        (coef, x, y, dz, dx, dy, p.num_rows, p.num_idx, unroll)
+
+    switch(cfg.N) {
+        case 4:  LAUNCH_BWD(4); break;
+        case 2:  LAUNCH_BWD(2); break;
+        default: LAUNCH_BWD(1); break;
+    };
+
+    #undef LAUNCH_BWD
+
+    cudaError_t launch_err = cudaGetLastError();
+    if (launch_err != cudaSuccess)
+        return e3j::Error::FromCudaLaunch(launch_err);
+
+    if (debug > 0) {
+        cudaError_t error = cudaDeviceSynchronize();
+        if (error != cudaSuccess) {
+            return e3j::Error::FromCudaLaunch(error);
+        }
+    }
+
+    return e3j::Error::Success();
+}
+
+
+} // namespace trailing_channels
+} // namespace tensor_product
+} // namespace e3j
+
+#endif // _E3J_TENSOR_PRODUCT_BWD_LAUNCH_TRAILING_H_

--- a/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
@@ -1,0 +1,247 @@
+#ifndef _E3J_TENSOR_PRODUCT_BWD_TRAILING_H_
+#define _E3J_TENSOR_PRODUCT_BWD_TRAILING_H_
+
+#include <cuda.h>
+
+#include "cuda/tensor_product_bwd.cuh"
+#include "cuda/tensor_product.cuh"
+#include "cuda/tensor_product/details.cuh"
+#include "cuda/tensor_product/debug.cuh"
+#include "cuda/tensor_product/trailing_channels.cuh"
+#include "cuda/dispatch_macros.h"
+#include "cuda/array.cuh"
+#include "cuda/utils.cuh"
+#include "ffi/error.h"
+
+#define BUFFER_BWD_COEFS_IN_SMEM true
+
+namespace e3j {
+namespace tensor_product {
+
+namespace trailing_channels {
+
+using utils::copy;
+using utils::wait_pipe;
+using utils::copy_pipe;
+using utils::copy_pipe_strided;
+using utils::fill;
+using utils::DeviceProperties;
+
+template <typename T>
+struct BuffersBwd {
+    CuArray2D<T> dz;
+    CuArray2D<T> x;
+    CuArray2D<T> y;
+    T* dxy;
+
+
+    static __device__ BuffersBwd init (
+        CuArray2D<const T> x, CuArray2D<const T> y, CuArray2D<const T> dz, dim3 unroll
+    ) {
+        return BuffersBwd {
+            .dz = { nullptr, dz.shape[0], unroll.z },
+            .x = { nullptr, x.shape[0], unroll.x },
+            .y = { nullptr, y.shape[0], unroll.y },
+            .dxy = nullptr,
+        };
+    }
+
+    template<int Stages=1>
+    __device__ void to_shared(char* smem_) {
+        constexpr int A = 16 / sizeof(T);
+        dz.data = reinterpret_cast<T*>(smem_);
+        x.data = dz.data + (Stages * dz.size() + A-1) / A * A;
+        y.data = x.data + (Stages * x.size() + A-1) / A * A;
+        dxy = y.data + (y.size() + A-1) / A * A;
+    }
+
+};
+
+
+template<typename Idx, typename Val, Mode dxMode, Mode dyMode, int N=1, bool Fused=true>
+__global__ void kernel_bwd(
+    const Coef<Idx,Val> *coef,
+    CuArray2D<const Val> x,
+    CuArray2D<const Val> y,
+    CuArray2D<const Val> dz,
+    CuArray2D<Val> dx,
+    CuArray2D<Val> dy,
+    int num_rows,
+    int num_coef,
+    dim3 unroll
+) {
+
+    using Coef = Coef<Idx,Val>;
+
+    // Map threads to (x,y,z) channels.
+    // Number of parallel channel triplets is k.total
+    Channels k_dx = Channels::get<dxMode, N>(
+        threadIdx.x, dz.shape[1], y.shape[1], dx.shape[1]
+    );
+    Channels k_dy = Channels::get<dyMode, N>(
+        threadIdx.x, dz.shape[1], x.shape[1], dy.shape[1]
+    );
+
+    unsigned int size_x = x.size(),
+                 size_y = y.size(),
+                 size_z = dz.size();
+
+    int num_warps = blockDim.x / 32;
+    constexpr bool inner_dx = (dxMode == Mode::INNER);
+    constexpr bool inner_dy = (dyMode == Mode::INNER);
+
+    // Shared memory layout: [ dz | x | y | scratch ]
+    extern __shared__ __align__(16) char smem__[];
+    char* smem_ = reinterpret_cast<char*>(smem__);
+
+    if constexpr (BUFFER_BWD_COEFS_IN_SMEM) {
+        // Copy coefficients at beginning of dynamic shared memory.
+        Coef* smem_coef = reinterpret_cast<Coef*>(smem_);
+        copy_pipe<1>(smem_coef, coef, 2 * num_coef);
+        // Overwrite reference to GMEM `coef` with SMEM buffer.
+        coef = smem_coef;
+        // Advance past the coef buffer, rounding up to 16 B so smem_x/y
+        // are 16-byte aligned for LDS.128 (N=4). This adds at most 8 B
+        // of padding when sizeof(Coef)==8 and num_idx is odd.
+        constexpr size_t align = N * sizeof(Val);
+        size_t coef_bytes = (size_t)num_coef * sizeof(Coef) * 2;
+        smem_ = (char*)smem_coef + ((coef_bytes + align - 1) & ~(align - 1));
+        // Wait for coef copy.
+        __pipeline_commit();
+        wait_pipe();
+    }
+
+    using BuffersBwd = BuffersBwd<Val>;
+
+    // Build SMEM Buffers for each pass, sharing underlying memory.
+    // dx pass: lhs=dz, rhs=y, out=scratch
+    // dy pass: lhs=dz, rhs=x, out=scratch
+    BuffersBwd smem = BuffersBwd::init(x, y, dz, unroll);
+    smem.to_shared(smem_);
+
+    const Coef *coef_dx = coef;
+    const Coef *coef_dy = coef + num_coef;
+
+    // Distribute coefficients across blockDim.y, without z-index overlap.
+    // Reuses dz buffer (not yet populated) as int[blockDim.y + 1] scratch.
+    int *smem_cuts = reinterpret_cast<int*>(smem.dz.data);
+    CoefRange coef_range_dx = find_coef_bounds<Idx, Val>(smem_cuts, coef_dx, num_coef, dx.shape[0]);
+    CoefRange coef_range_dy = find_coef_bounds<Idx, Val>(smem_cuts, coef_dy, num_coef, dy.shape[0]);
+
+    // Block-wise row offsets
+    x.data += blockIdx.x * size_x;
+    y.data += blockIdx.x * size_y;
+    dz.data += blockIdx.x * size_z;
+    dx.data += blockIdx.x * size_x;
+    dy.data += blockIdx.x * size_y;
+
+    //=== Grid stride loop ===
+    for (int row = blockIdx.x; row < num_rows; row += gridDim.x) {
+
+        unsigned int cx = x.shape[1],
+                     cy = y.shape[1],
+                     cz = dz.shape[1];
+
+        int num_strides = 1 + (max(max(cx, cy), cz) - 1) / (blockDim.x * N);
+
+        // Zero-out the scratch SMEM buffer if INNER and channel striding,
+        if constexpr (inner_dx || inner_dy) {
+            int scratch_n = inner_dx ? dx.shape[0] : dy.shape[0];
+            fill(smem.dxy, Val(0), num_warps * scratch_n);
+            __syncthreads();
+        }
+
+        // Stride-local GMEM views, advanced per channel slice.
+        CuArray2D<const Val> dz_s = { dz.data, dz.shape[0], cz };
+        CuArray2D<const Val> x_s  = { x.data,  x.shape[0],  cx  };
+        CuArray2D<const Val> y_s  = { y.data,  y.shape[0],  cy  };
+        CuArray2D<Val> dx_s = { dx.data, dx.shape[0], cx };
+        CuArray2D<Val> dy_s = { dy.data, dy.shape[0], cy };
+
+        //=== Channel stride loop ===
+        for (int s = 0; s < num_strides; s++) {
+
+            // Load dz and y — needed by the dx pass.
+            // Broadcast operands (n_channels <= unroll) are contiguous:
+            // use copy_pipe<1> to avoid 16 B alignment requirement.
+            if (cz > unroll.z)
+                copy_pipe_strided(smem.dz.data, dz_s.data, dz.shape[0], unroll.z, cz);
+            else
+                copy_pipe<1>(smem.dz.data, dz_s.data, smem.dz.size());
+
+            if (cy > unroll.y)
+                copy_pipe_strided(smem.y.data, y_s.data, y.shape[0], unroll.y, cy);
+            else
+                copy_pipe<1>(smem.y.data, y_s.data, smem.y.size());
+            __pipeline_commit();
+
+            // Issue x load — overlaps with the dx otimes below.
+            if (cx > unroll.x)
+                copy_pipe_strided(smem.x.data, x_s.data, x.shape[0], unroll.x, cx);
+            else
+                copy_pipe<1>(smem.x.data, x_s.data, smem.x.size());
+            __pipeline_commit();
+
+            // Drain dz + y (pipeline group 0).
+            wait_pipe<1>();
+
+            // Compute dx: reads dz + y (complete), does not touch smem.x.
+            otimes<Idx,Val,dxMode, N, inner_dx>(
+                coef_dx, coef_range_dx, smem.dz, smem.y, dx_s, k_dx, smem.dxy
+            );
+
+            // Drain x (pipeline group 1).
+            wait_pipe();
+
+            // Compute dy: reads dz + x (now complete).
+            otimes<Idx,Val,dyMode, N, inner_dy>(
+                coef_dy, coef_range_dy, smem.dz, smem.x, dy_s, k_dy, smem.dxy
+            );
+
+            __syncthreads();
+
+            // Advance to next channel slice (no-op for broadcast operands)
+            if (cz > unroll.z) dz_s.data += unroll.z;
+            if (cx > unroll.x) x_s.data  += unroll.x;
+            if (cy > unroll.y) y_s.data  += unroll.y;
+            if (!inner_dx && cx > unroll.x) dx_s.data += unroll.x;
+            if (!inner_dy && cy > unroll.y) dy_s.data += unroll.y;
+
+        }//=== Channel stride loop ===
+
+        // Flush INNER scratch to GMEM after all strides
+        if constexpr (inner_dx) {
+            for (unsigned int i = threadIdx.x; i < dx.shape[0]; i += blockDim.x) {
+                Val sum = 0;
+                for (int w = 0; w < num_warps; w++)
+                    sum += smem.dxy[w * dx.shape[0] + i];
+                dx.data[i] = sum;
+            }
+            __syncthreads();
+        }
+        if constexpr (inner_dy) {
+            for (unsigned int i = threadIdx.x; i < dy.shape[0]; i += blockDim.x) {
+                Val sum = 0;
+                for (int w = 0; w < num_warps; w++)
+                    sum += smem.dxy[w * dy.shape[0] + i];
+                dy.data[i] = sum;
+            }
+            __syncthreads();
+        }
+
+        // Update GMEM pointers
+        dz.data += gridDim.x * size_z;
+        x.data  += gridDim.x * size_x;
+        y.data  += gridDim.x * size_y;
+        dx.data += gridDim.x * size_x;
+        dy.data += gridDim.x * size_y;
+
+    }//=== Grid stride loop ===
+
+}
+
+} // namespace trailing_channels
+} // namespace tensor_product
+} // namespace e3j
+
+#endif // _E3J_TENSOR_PRODUCT_BWD_TRAILING_H_

--- a/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
@@ -1,3 +1,18 @@
+/* Copyright (c) 2026 InstaDeep Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef _E3J_TENSOR_PRODUCT_BWD_TRAILING_H_
 #define _E3J_TENSOR_PRODUCT_BWD_TRAILING_H_
 

--- a/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
@@ -167,7 +167,7 @@ __global__ void kernel_bwd(
             if (cz > unroll.z)
                 copy_pipe_strided(smem.dz.data, dz_s.data, dz.shape[0], unroll.z, cz);
             else
-                copy_pipe<1>(smem.dz.data, dz_s.data, smem.dz.size());
+                copy_pipe<N>(smem.dz.data, dz_s.data, smem.dz.size());
 
             if (cy > unroll.y)
                 copy_pipe_strided(smem.y.data, y_s.data, y.shape[0], unroll.y, cy);
@@ -179,7 +179,7 @@ __global__ void kernel_bwd(
             if (cx > unroll.x)
                 copy_pipe_strided(smem.x.data, x_s.data, x.shape[0], unroll.x, cx);
             else
-                copy_pipe<1>(smem.x.data, x_s.data, smem.x.size());
+                copy_pipe<N>(smem.x.data, x_s.data, smem.x.size());
             __pipeline_commit();
 
             // Drain dz + y (pipeline group 0).

--- a/lib/e3j_ops/ffi/e3j_ops.cpp
+++ b/lib/e3j_ops/ffi/e3j_ops.cpp
@@ -27,6 +27,7 @@ py::dict GetRegistrations () {
     py::dict ops;
     ops["scatter_add_1"] = e3j_ops::pyEncapsulateFunction(e3j_ops::xla_scatter_add_1);
     ops["tensor_product"] = e3j_ops::pyEncapsulateFunction(e3j_ops::xla_tensor_product);
+    ops["tensor_product_bwd"] = e3j_ops::pyEncapsulateFunction(e3j_ops::xla_tensor_product_bwd);
     return ops;
 }
 

--- a/lib/e3j_ops/ffi/e3j_ops.h
+++ b/lib/e3j_ops/ffi/e3j_ops.h
@@ -40,6 +40,7 @@
 #include "cuda/fill.cuh"
 #include "cuda/scatter_add.cuh"
 #include "cuda/tensor_product.cuh"
+#include "cuda/tensor_product_bwd.cuh"
 
 /* Boilerplate DTYPE macros are now in dispatch_macros.h:
  *
@@ -248,6 +249,128 @@ XLA_FFI_DEFINE_HANDLER(
         .Attr<int32_t>("debug")
 );
 
+
+//===----------------------------------------------------------===//
+//  tensor_product_bwd
+//===----------------------------------------------------------===//
+xla::Error TensorProductBwdHandler(
+    cudaStream_t stream,
+    xla::AnyBuffer coef,
+    xla::AnyBuffer x,
+    xla::AnyBuffer y,
+    xla::AnyBuffer dz,
+    xla::Result<xla::AnyBuffer> dx,
+    xla::Result<xla::AnyBuffer> dy,
+    int32_t _mode_fwd,
+    int32_t _layout,
+    int32_t unroll_x = 1,
+    int32_t unroll_y = 1,
+    int32_t unroll_z = 1,
+    int debug = 0
+) {
+
+    // Parse mode and layout from int: see `e3j.utils.options`
+    // for the python Enums that must match those of
+    // `tensor_product.cuh`.
+    using e3j::tensor_product::Mode;
+    using e3j::tensor_product::Layout;
+    Mode mode_fwd = Mode(_mode_fwd);
+    Layout layout = Layout(_layout);
+
+    // Coefficients for dx + dy should be concatenated from Python.
+    // We rely on `element_count()` instead of Dimensions
+    // for robustness, in case stack/concat of coef changes.
+    int32_t numel = coef.dimensions().back();
+    int32_t num_idx = coef.element_count() / (2 * numel);
+
+    xla::AnyBuffer::Dimensions dims_x = x.dimensions();
+    xla::AnyBuffer::Dimensions dims_y = y.dimensions();
+    xla::AnyBuffer::Dimensions dims_z = dz.dimensions();
+
+    int32_t num_x, num_y, num_z, channels_x, channels_y;
+    switch (layout) {
+        case Layout::LEADING_CHANNELS:
+            num_x = dims_x.back();
+            num_y = dims_y.back();
+            num_z = dims_z.back();
+            channels_x = dims_x.size() > 2 ? dims_x[1] : 1;
+            channels_y = dims_y.size() > 2 ? dims_y[1] : 1;
+            break;
+        case Layout::TRAILING_CHANNELS:
+            num_x = dims_x[1];
+            num_y = dims_y[1];
+            num_z = dims_z[1];
+            channels_x = dims_x.size() > 2 ? dims_x.back() : 1;
+            channels_y = dims_y.size() > 2 ? dims_y.back() : 1;
+            break;
+        default: exit(1);
+    }
+
+    int32_t num_rows = x.element_count() / (num_x * channels_x);
+
+    e3j::tensor_product::Params params_fwd = {
+        .num_rows = num_rows,
+        .num_idx = num_idx,
+        .num_x = num_x,
+        .num_y = num_y,
+        .num_out = num_z,
+        .channels_x = channels_x,
+        .channels_y = channels_y,
+        .mode = mode_fwd,
+        .unroll_x = unroll_x,
+        .unroll_y = unroll_y,
+        .unroll_z = unroll_z,
+        .layout = layout
+    };
+
+    using e3j::tensor_product::trailing_channels::launch_bwd;
+
+    #define DISPATCH_DTYPE_PAIR_ERROR(IDX_T, VAL_T)          \
+        return e3j::Error::InvalidArgument(                  \
+            "unsupported (IDX, VAL) dtype pair").to_xla();
+
+    #define DISPATCH_DTYPE_PAIR(Idx, Val)                       \
+        using Coef = e3j::tensor_product::Coef<Idx, Val>;       \
+        const Coef *coef_ptr = reinterpret_cast<const Coef*>(   \
+            coef.typed_data<Idx>()                              \
+        );                                                      \
+                                                                \
+        return launch_bwd<Idx, Val>(                            \
+            coef_ptr,                                           \
+            x.typed_data<Val>(),                                \
+            y.typed_data<Val>(),                                \
+            dz.typed_data<Val>(),                               \
+            dx->typed_data<Val>(),                              \
+            dy->typed_data<Val>(),                              \
+            params_fwd, stream, debug                           \
+        ).to_xla();
+
+    __DISPATCH_DTYPE_PAIR(coef.element_type(), x.element_type())
+    #undef DISPATCH_DTYPE_PAIR
+    #undef DISPATCH_DTYPE_PAIR_ERROR
+
+    return xla::Error::Success();
+};
+
+
+XLA_FFI_DEFINE_HANDLER(
+    xla_tensor_product_bwd,
+    TensorProductBwdHandler,
+    xla::Ffi::Bind()
+        .Ctx<xla::PlatformStream<cudaStream_t>>()
+        .Arg<xla::AnyBuffer>()   // coef
+        .Arg<xla::AnyBuffer>()   // x
+        .Arg<xla::AnyBuffer>()   // y
+        .Arg<xla::AnyBuffer>()   // z
+        .Ret<xla::AnyBuffer>()   // dx
+        .Ret<xla::AnyBuffer>()   // dy
+        .Attr<int32_t>("mode")
+        .Attr<int32_t>("layout")
+        .Attr<int32_t>("unroll_x")
+        .Attr<int32_t>("unroll_y")
+        .Attr<int32_t>("unroll_z")
+        .Attr<int32_t>("debug")
+);
 
 
 } // namespace e3j_ops

--- a/lib/e3j_ops/ffi/e3j_ops.h
+++ b/lib/e3j_ops/ffi/e3j_ops.h
@@ -120,9 +120,6 @@ xla::Error TensorProductHandler(
     int32_t num_out,
     int32_t _mode,
     int32_t _layout,
-    int32_t unroll_x = 1,
-    int32_t unroll_y = 1,
-    int32_t unroll_z = 1,
     int debug = 0
 ) {
 
@@ -206,9 +203,6 @@ xla::Error TensorProductHandler(
             .channels_x = channels_x,                           \
             .channels_y = channels_y,                           \
             .mode = mode,                                       \
-            .unroll_x = unroll_x,                               \
-            .unroll_y = unroll_y,                               \
-            .unroll_z = unroll_z,                               \
             .layout = layout                                    \
         };                                                      \
         return e3j::tensor_product::launch<Idx, Val>(           \
@@ -243,9 +237,6 @@ XLA_FFI_DEFINE_HANDLER(
         .Attr<int32_t>("num_out")
         .Attr<int32_t>("mode")
         .Attr<int32_t>("layout")
-        .Attr<int32_t>("unroll_x")
-        .Attr<int32_t>("unroll_y")
-        .Attr<int32_t>("unroll_z")
         .Attr<int32_t>("debug")
 );
 
@@ -263,9 +254,6 @@ xla::Error TensorProductBwdHandler(
     xla::Result<xla::AnyBuffer> dy,
     int32_t _mode_fwd,
     int32_t _layout,
-    int32_t unroll_x = 1,
-    int32_t unroll_y = 1,
-    int32_t unroll_z = 1,
     int debug = 0
 ) {
 
@@ -317,9 +305,6 @@ xla::Error TensorProductBwdHandler(
         .channels_x = channels_x,
         .channels_y = channels_y,
         .mode = mode_fwd,
-        .unroll_x = unroll_x,
-        .unroll_y = unroll_y,
-        .unroll_z = unroll_z,
         .layout = layout
     };
 
@@ -366,9 +351,6 @@ XLA_FFI_DEFINE_HANDLER(
         .Ret<xla::AnyBuffer>()   // dy
         .Attr<int32_t>("mode")
         .Attr<int32_t>("layout")
-        .Attr<int32_t>("unroll_x")
-        .Attr<int32_t>("unroll_y")
-        .Attr<int32_t>("unroll_z")
         .Attr<int32_t>("debug")
 );
 

--- a/lib/e3j_ops/pyproject.toml
+++ b/lib/e3j_ops/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "e3j_ops"
-version = "0.1.0b1"
+version = "0.1.0b2"
 description = "Fast Euclid equivariant operations for JAX"
 authors = [
     { name="Olivier Peltre", email="o.peltre@instadeep.com" }

--- a/lib/e3j_ops/tests/test_tensor_product_bwd.cpp
+++ b/lib/e3j_ops/tests/test_tensor_product_bwd.cpp
@@ -1,0 +1,462 @@
+#include <cstdint>
+#include <iostream>
+#include <stdio.h>
+#include <algorithm>
+
+#include <map>
+
+#include "vec.h"
+
+#include "cuda.h"
+#include "cuda_runtime_api.h"
+
+#include "cuda/tensor_product_bwd.cuh"
+
+#define NUM_ROWS 12
+#define NUM_CHANNELS 32 // FIXME: TRAILING_CHANNELS requires 32-multiple
+#define NUM_STRIPS 3
+
+#define UNROLL_Y 1
+#define UNROLL_Z 1
+
+#define LOG false
+#define DEBUG 2
+
+#define ASSERT_EQUAL(LHS, RHS, MSG)             \
+    if (LHS != RHS) {                           \
+        std::cout << "ASSERT_EQUAL:" << MSG;    \
+        std::cout << "\n";                      \
+        std::cout << LHS << "!=" << RHS;        \
+        std::cout << "\n";                      \
+        exit(1);                                \
+    }
+
+
+using e3j::tensor_product::Params;
+using e3j::tensor_product::Mode;
+using e3j::tensor_product::Layout;
+using e3j::tensor_product::Coef;
+
+using vec::Vec;
+
+template <typename Idx>
+struct Args {
+    std::vector<Coef<Idx, float>> coef;
+    Vec<float> x;
+    Vec<float> y;
+    Vec<float> dz;
+    Vec<float> dx;
+    Vec<float> dy;
+};
+
+template <typename Idx>
+std::vector<Coef<Idx, float>> packCoefs(
+    Vec<Idx> idx_flat, Vec<float> val, int nnz
+) {
+    std::vector<Coef<Idx, float>> out(nnz);
+    for (int n = 0; n < nnz; n++) {
+        out[n] = {
+            .val = val[n],
+            .i = idx_flat[n],
+            .j = idx_flat[n + nnz],
+            .k = idx_flat[n + nnz * 2],
+        };
+    }
+    return out;
+}
+
+template <typename Idx>
+Args<Idx> prepareHostArgs (Params p, int num_strips=NUM_STRIPS) {
+
+    int n_idx = 6;
+    // Strip-wise data:
+    // (z, x, y) order for forward pass (unused)
+    Vec<Idx> idx_zxy {
+        0, 0, 0,
+        1, 0, 1,
+        2, 0, 2,
+        3, 1, 0,
+        4, 1, 1,
+        5, 1, 2
+    };
+    // (x, z, y) also lexsorted
+    Vec<Idx> idx_xzy {
+        0, 0, 0,
+        0, 1, 1,
+        0, 2, 2,
+        1, 3, 0,
+        1, 4, 1,
+        1, 5, 2
+    };
+    // (y, z, x) lexsort
+    Vec<Idx> idx_yzx {
+        0, 0, 0,
+        0, 3, 1,
+        1, 1, 0,
+        1, 4, 1,
+        2, 2, 0,
+        2, 5, 1,
+    };
+
+    // Transpose and repeat indices with offsets
+    Vec<float> coef_xzy = {1., 2., 3., 4., 5., 6.};
+    Vec<float> coef_yzx = {1., 4., 2., 5., 3., 6.};
+
+    printf("indices before repeats and offsets:\n");
+    vec::showMatrix(std::cout, idx_xzy.data(), 3, n_idx);
+    vec::showMatrix(std::cout, idx_yzx.data(), 3, n_idx);
+
+    idx_xzy = transpose_trailing_axes(idx_xzy, n_idx, 3);
+    idx_yzx = transpose_trailing_axes(idx_yzx, n_idx, 3);
+
+    idx_xzy = idx_xzy.tile_trailing(num_strips, n_idx);
+    idx_yzx = idx_yzx.tile_trailing(num_strips, n_idx);
+
+    idx_xzy = idx_xzy + Vec<Idx>::concat({
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(2),
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(6),
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(3)
+    });
+    idx_yzx = idx_yzx + Vec<Idx>::concat({
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(3),
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(6),
+        vec::arange<Idx>(num_strips).repeat(n_idx) * Idx(2)
+    });
+
+    // Pack each coefficient set into Coef<Idx,float> structs
+    int nnz = n_idx * num_strips;
+    Vec<float> val_xzy = coef_xzy.tile(num_strips);
+    Vec<float> val_yzx = coef_yzx.tile(num_strips);
+
+    std::vector<Coef<Idx, float>> packed_xzy = packCoefs<Idx>(idx_xzy, val_xzy, nnz);
+    std::vector<Coef<Idx, float>> packed_yzx = packCoefs<Idx>(idx_yzx, val_yzx, nnz);
+
+    // Concatenate dx and dy coefficient sets
+    std::vector<Coef<Idx, float>> coef_packed;
+    coef_packed.reserve(2 * nnz);
+    coef_packed.insert(coef_packed.end(), packed_xzy.begin(), packed_xzy.end());
+    coef_packed.insert(coef_packed.end(), packed_yzx.begin(), packed_yzx.end());
+
+    // Input operands
+    Vec<float> x_ = {1., 1.};
+    Vec<float> y_ = {1., 1., 1.};
+    Vec<float> dz_ = {1., 1., 1., 1., 1., 1.};
+
+    // Output buffers
+    Vec<float> dx_ = {0., 0.};
+    Vec<float> dy_ = {0., 0., 0.};
+
+    // Repeat index patterns across strips
+    int cx = p.channels_x,
+        cy = p.channels_y,
+        cz = p.channels_out();
+
+    // Multiply y and result channel axis by vec::arange(NUM_CHANNELS)
+    Vec<float> scale_y = (vec::arange<float>(cy) + 1)
+        .repeat(num_strips * y_.size())
+        .tile(p.num_rows);
+
+    // Repeat other operands
+    Args<Idx> args = {
+        .coef = coef_packed,
+        .x = x_.tile(p.num_rows * cx * num_strips),
+        .y = y_.tile(p.num_rows * cy * num_strips) * scale_y,
+        .dz = dz_.tile(p.num_rows * cz * num_strips),
+        .dx = dx_.tile(p.num_rows * cx * num_strips),
+        .dy = dy_.tile(p.num_rows * cy * num_strips),
+    };
+
+    // Transpose depending on layout
+    if (p.layout == Layout::TRAILING_CHANNELS) {
+        printf("Layout::TRAILING_CHANNELS\n");
+        args = Args<Idx> {
+            .coef = args.coef,
+            .x = transpose_trailing_axes(args.x, p.channels_x, p.num_x),
+            .y = transpose_trailing_axes(args.y, p.channels_y, p.num_y),
+            .dz = transpose_trailing_axes(args.dz, cz, p.num_out),
+            .dx = args.dx,
+            .dy = args.dy
+        };
+    }
+    ASSERT_EQUAL(p.num_x * p.num_rows * p.channels_x, (int)args.x.size(), "x")
+    ASSERT_EQUAL(p.num_x * p.num_rows * p.channels_x, (int)args.dx.size(), "dx")
+    ASSERT_EQUAL(p.num_y * p.num_rows * p.channels_y, (int)args.y.size(), "y")
+    ASSERT_EQUAL(p.num_y * p.num_rows * p.channels_y, (int)args.dy.size(), "dy")
+    ASSERT_EQUAL(p.num_out * p.num_rows * p.channels_out(), (int)args.dz.size(), "dz")
+    ASSERT_EQUAL(2 * p.num_idx, (int)args.coef.size(), "coef")
+    return args;
+}
+
+
+void showOutput (float* data, int channels, int features, Params p) {
+
+    if (p.layout == Layout::LEADING_CHANNELS)
+        vec::showMatrix(std::cout, data, channels, features);
+
+    else if (p.layout == Layout::TRAILING_CHANNELS)
+        vec::showMatrix(std::cout, data, channels, features);
+}
+
+
+void checkOutput (float* out, float* res, int channels_z, Params p) {
+
+    int num_rows = p.num_rows,
+        num_out = p.num_out;
+
+	bool success = true;
+
+    for (int k = 0; k < num_rows * num_out * channels_z; k++) {
+		int col_k = k % num_out;
+		success &= (out[k] == res[k]);
+		if (LOG) {
+            printf((col_k < num_out - 1 ? "%.1f " : "%.1f\n     "), out[k]);
+        }
+	}
+
+    if (DEBUG >= 2 or not success)  {
+        // printf("expect:\n"); showOutput(res, channels_z, p);
+        // printf("result:\n"); showOutput(out, channels_z, p);
+    }
+
+    printf(success ? "✅\n" : "❌\n");
+}
+
+
+
+template <typename Idx>
+int test_tensor_product_bwd (Params p, int num_strips=NUM_STRIPS) {
+
+    #define H2D cudaMemcpyHostToDevice
+    #define D2H cudaMemcpyDeviceToHost
+
+    using namespace e3j::tensor_product;
+
+    using e3j::tensor_product::trailing_channels::launch_bwd;
+
+    printf("=== Test tensor_product_bwd ===================================\n");
+
+    std::map<Mode, char const*> modes = {
+        {Mode::INNER, "INNER"},
+        {Mode::OUTER, "OUTER"},
+        {Mode::MAP, "MAP"},
+    };
+    std::cout << "Mode::" << modes[p.mode] << "\n";
+    printf("Idx size: %zu bytes\n", sizeof(Idx));
+
+    using CoefT = Coef<Idx, float>;
+
+    Args<Idx> args = prepareHostArgs<Idx>(p, num_strips);
+
+	printf("Moving inputs to device...\n");
+
+    CoefT *coef_d;
+    float *x_d, *y_d, *dz_d, *dx_d, *dy_d;
+
+    int cz = p.channels_out();
+
+    size_t size_coef = sizeof(CoefT) * 2 * p.num_idx,
+           size_x = sizeof(float) * p.num_rows * p.num_x * p.channels_x,
+           size_y = sizeof(float) * p.num_rows * p.num_y * p.channels_y,
+           size_z = sizeof(float) * p.num_rows * p.num_out * cz;
+
+	cudaMalloc((void**)&coef_d, size_coef);
+	cudaMalloc((void**)&x_d, size_x);
+	cudaMalloc((void**)&y_d, size_y);
+	cudaMalloc((void**)&dz_d, size_z);
+	cudaMalloc((void**)&dx_d, size_x);
+	cudaMalloc((void**)&dy_d, size_y);
+
+	cudaMemcpy(coef_d, args.coef.data(), size_coef, H2D);
+	cudaMemcpy(x_d, args.x.data(), size_x, H2D);
+	cudaMemcpy(y_d, args.y.data(), size_y, H2D);
+	cudaMemcpy(dz_d, args.dz.data(), size_z, H2D);
+	cudaMemcpy(dx_d, args.dx.data(), size_x, H2D);
+	cudaMemcpy(dy_d, args.dy.data(), size_y, H2D);
+
+    cudaDeviceSynchronize();
+
+    printf("Calling backward tensor product kernel...\n");
+
+    launch_bwd<Idx, float>(
+        coef_d,
+        x_d, y_d, dz_d,
+        dx_d, dy_d,
+        p, cudaStream_t(0), DEBUG
+    );
+
+    cudaDeviceSynchronize();
+
+    Vec<float> result_dx (args.dx.size());
+    Vec<float> result_dy (args.dy.size());
+    cudaMemcpy(result_dx.data(), dx_d, size_x, D2H);
+    cudaMemcpy(result_dy.data(), dy_d, size_y, D2H);
+
+    cudaDeviceSynchronize();
+
+    // Infer backward parameters on dx and dy
+    ParamsBwd p_bwd = GetParamsBwd(p);
+    Params p_dx = p_bwd.lhs,
+           p_dy = p_bwd.rhs;
+
+    printf("Calling the two equivalent tensor product kernels...\n");
+
+    // Flush outputs
+	cudaMemcpy(dx_d, args.dx.data(), size_x, H2D);
+	cudaMemcpy(dy_d, args.dy.data(), size_y, H2D);
+
+    // Split packed coefficients: first p.num_idx for dx, next for dy
+    CoefT *coef_dx = coef_d,
+          *coef_dy = coef_d + p.num_idx;
+
+    // Call two TP kernels.
+    cudaDeviceSynchronize();
+
+    launch<Idx, float>(
+        coef_dx,
+        dz_d, y_d, dx_d,
+        p_dx, cudaStream_t(0), DEBUG
+    );
+    launch<Idx, float>(
+        coef_dy,
+        dz_d, x_d, dy_d,
+        p_dy, cudaStream_t(0), DEBUG
+    );
+
+    // Collect expected results
+    cudaDeviceSynchronize();
+
+    Vec<float> expect_dx (args.dx.size());
+    Vec<float> expect_dy (args.dy.size());
+
+    cudaMemcpy(expect_dx.data(), dx_d, size_x, D2H);
+    cudaMemcpy(expect_dy.data(), dy_d, size_y, D2H);
+    cudaDeviceSynchronize();
+
+    bool dx_match = true, dy_match = true;
+    for (int i = 0; i < (int)expect_dx.size(); i++)
+        dx_match &= (result_dx[i] == expect_dx[i]);
+    for (int i = 0; i < (int)expect_dy.size(); i++)
+        dy_match &= (result_dy[i] == expect_dy[i]);
+
+    printf("dx: %s\n", dx_match ? "✅" : "❌");
+    printf("dy: %s\n", dy_match ? "✅" : "❌");
+
+    if (!dx_match) {
+        printf("Expect dx:\n");
+        showOutput(expect_dx.data(), 3 * p.num_x, p.channels_x, p);
+        printf("Result dx:\n");
+        showOutput(result_dx.data(), 3 * p.num_x, p.channels_x, p_dx);
+    }
+    if (!dy_match) {
+        printf("Expect dy:\n");
+        showOutput(expect_dy.data(), 3 * p.num_y, p.channels_y, p);
+        printf("Result dy:\n");
+        showOutput(result_dy.data(), 3 * p.num_y, p.channels_y, p_dy);
+    }
+
+    cudaFree(coef_d);
+    cudaFree(x_d);
+    cudaFree(y_d);
+    cudaFree(dz_d);
+    cudaFree(dx_d);
+    cudaFree(dy_d);
+    return 0;
+}
+
+
+Params GetParams(Mode mode, int channels, int num_strips=NUM_STRIPS) {
+    int num_idx = 6 * num_strips;
+    int num_x = 2 * num_strips;
+    int num_y = 3 * num_strips;
+    int num_out = 6 * num_strips;
+    int channels_x = (mode == Mode::OUTER) ? 1 : channels;
+    int channels_y = channels;
+    return Params {
+        /*num_rows*/NUM_ROWS,
+        /*num_idx*/num_idx,
+        /*num_x*/num_x,
+        /*num_y*/num_y,
+        /*num_out*/num_out,
+        /*channels_x*/channels_x,
+        /*channels_y*/channels_y,
+        /*mode*/mode,
+        /*unroll_x*/1,
+        /*unroll_y*/1,
+        /*unroll_z*/1,
+        /*layout*/Layout::TRAILING_CHANNELS
+    };
+}
+
+// OUTER with channels on x, broadcast on y — the message passing layout.
+// Backward modes: {OUTER, INNER} (vs {INNER, OUTER} from GetParams).
+Params GetParamsOuterX(int channels, int num_strips=NUM_STRIPS) {
+    int num_idx = 6 * num_strips;
+    int num_x = 2 * num_strips;
+    int num_y = 3 * num_strips;
+    int num_out = 6 * num_strips;
+    return Params {
+        /*num_rows*/NUM_ROWS,
+        /*num_idx*/num_idx,
+        /*num_x*/num_x,
+        /*num_y*/num_y,
+        /*num_out*/num_out,
+        /*channels_x*/channels,
+        /*channels_y*/1,
+        /*mode*/Mode::OUTER,
+        /*unroll_x*/1,
+        /*unroll_y*/1,
+        /*unroll_z*/1,
+        /*layout*/Layout::TRAILING_CHANNELS
+    };
+}
+
+int main() {
+
+    // --- int32_t, 32 channels (N=1) ---
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::OUTER, 32));
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::INNER, 32));
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::MAP,   32));
+
+    // --- int32_t, 64 channels (N=2) ---
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::OUTER, 64));
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::MAP,   64));
+
+    // --- int32_t, 512 channels (N=4, multi-stride) ---
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::OUTER, 512));
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::INNER, 512));
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::MAP,   512));
+
+    // --- uint8_t, 32 channels (N=1) ---
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::OUTER, 32));
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::INNER, 32));
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::MAP,   32));
+
+    // --- uint8_t, 64 channels (N=2) ---
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::OUTER, 64));
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::MAP,   64));
+
+    // --- uint8_t, 512 channels (N=4, multi-stride) ---
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::OUTER, 512));
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::MAP,   512));
+
+    // --- OUTER with channels on x (message passing layout) ---
+    // Backward modes: {OUTER, INNER} — not covered by GetParams.
+    test_tensor_product_bwd<std::int32_t>(GetParamsOuterX(32));
+    test_tensor_product_bwd<std::int32_t>(GetParamsOuterX(64));
+    test_tensor_product_bwd<std::int32_t>(GetParamsOuterX(512));
+    test_tensor_product_bwd<std::uint8_t>(GetParamsOuterX(32));
+    test_tensor_product_bwd<std::uint8_t>(GetParamsOuterX(64));
+    test_tensor_product_bwd<std::uint8_t>(GetParamsOuterX(512));
+
+    // --- Large num_strips: triggers SMEM opt-in and channel striding ---
+    int large = 40;
+
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::OUTER, 32, large), large);
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::OUTER, 64, large), large);
+    test_tensor_product_bwd<std::int32_t>(GetParams(Mode::MAP,   64, large), large);
+    test_tensor_product_bwd<std::uint8_t>(GetParams(Mode::OUTER, 64, large), large);
+
+    test_tensor_product_bwd<std::int32_t>(GetParamsOuterX(32, large), large);
+    test_tensor_product_bwd<std::int32_t>(GetParamsOuterX(64, large), large);
+    test_tensor_product_bwd<std::uint8_t>(GetParamsOuterX(64, large), large);
+}

--- a/lib/e3j_ops/tests/test_tensor_product_bwd.cpp
+++ b/lib/e3j_ops/tests/test_tensor_product_bwd.cpp
@@ -1,3 +1,18 @@
+/* Copyright (c) 2026 InstaDeep Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <cstdint>
 #include <iostream>
 #include <stdio.h>

--- a/lib/e3j_ops/tests/vec.h
+++ b/lib/e3j_ops/tests/vec.h
@@ -143,6 +143,21 @@ class Vec {
             return out;
         }
 
+        Vec tile_trailing (int k, int dim_last) {
+            int n = size();
+            int nk = dim_last * k;
+            int rows = n / dim_last;
+            printf("Vec(%d)\n", n * k);
+            Vec out = Vec(n * k);
+            printf("out: %d\n", out.size());
+            for (int r = 0; r < rows; r++) {
+                for (int i = 0; i < nk; i++) {
+                    out[r * nk + i] = _data[r * dim_last + (i % dim_last)];
+                }
+            }
+            return out;
+        }
+
         template <typename B>
         Vec<B> map (std::function<B(T)> f) {
             Vec<B> out (size());

--- a/lib/e3j_ops/tests/vec.h
+++ b/lib/e3j_ops/tests/vec.h
@@ -147,9 +147,7 @@ class Vec {
             int n = size();
             int nk = dim_last * k;
             int rows = n / dim_last;
-            printf("Vec(%d)\n", n * k);
             Vec out = Vec(n * k);
-            printf("out: %d\n", out.size());
             for (int r = 0; r < rows; r++) {
                 for (int i = 0; i < nk; i++) {
                     out[r * nk + i] = _data[r * dim_last + (i % dim_last)];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e3j"
-version = "0.1.0b1"
+version = "0.1.0b2"
 description = "Fast Euclid equivariant operations for JAX"
 authors = [
     { name="Olivier Peltre", email="o.peltre@instadeep.com" },
@@ -24,7 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ops = [
-    "e3j_ops == 0.1.0b1",
+    "e3j_ops == 0.1.0b2",
     "pybind11 >= 2.13.6"
 ]
 

--- a/src/e3j/core/tensor_product.py
+++ b/src/e3j/core/tensor_product.py
@@ -69,7 +69,6 @@ class TensorProduct(SparseMixin):
         target: O3Space | str | None,
         coef: Optional[sparse.BCOO] = None,
         sort: bool = True,
-        unroll: int | tuple[int, int, int] = 1,
         config: utils.Config | None = None,
         layout: str | options.Layout = "LEADING_CHANNELS",
         mode: str | options.TPMode = "OUTER",
@@ -137,16 +136,6 @@ class TensorProduct(SparseMixin):
 
         # --- Coefficients ---
 
-        # Unroll coefficients by expanding feature sizes
-        if isinstance(unroll, tuple) and len(unroll) == 3:
-            self.unroll = unroll
-        elif isinstance(unroll, tuple) and len(unroll) == 2:
-            self.unroll = (1, *unroll)
-        elif isinstance(unroll, int):
-            self.unroll = (1, unroll, unroll)
-        else:
-            raise ValueError("unroll: should be int or tuple[int, int, int]")
-
         # Fill cache from pre-computed coefficients
         if coef is not None:
             self.coef = coef
@@ -202,7 +191,6 @@ class TensorProduct(SparseMixin):
             perm.target,
             coef=coef,
             sort=False,
-            unroll=self.unroll,
         )
 
     @staticmethod
@@ -329,14 +317,12 @@ class TensorProduct(SparseMixin):
         x: Array,
         y: Array,
         coef: Array,
-        unroll: int | tuple[int, int] = 1,
     ) -> Array:
         """Evaluate bilinear map on pair of inputs."""
         idx = coef.indices
         val = coef.data
         params = Params(
             num_out=self.target.dim,
-            unroll=self.unroll,
             layout=self.layout,
             mode=self.mode,
         )
@@ -354,8 +340,6 @@ class TensorProduct(SparseMixin):
         if self.is_dense:
             return self.dense_eval(x, y, coef)
         if self.is_fused:
-            with jax.ensure_compile_time_eval():
-                unroll = tuple(numpy.int32(k) for k in self.unroll)
-            return self.fused_eval(x, y, coef, unroll=unroll)
+            return self.fused_eval(x, y, coef)
         else:
             return self.sparse_eval(x, y, coef)

--- a/src/e3j/ops/coef.py
+++ b/src/e3j/ops/coef.py
@@ -122,6 +122,16 @@ class Coef:
         coef_cast = coef_np.view(idx_t).reshape(-1, numel)
         return jnp.asarray(coef_cast)
 
+    def transpose(self, argnums: tuple[int, int, int]) -> "Coef":
+        """Transposed COO coefficients with sorted indices and values."""
+        # Note: Lexsorting indices *might* reduce bank conflicts.
+        val, idx = self.val, self.idx.T
+        a, b, c = argnums
+        sigma = jnp.argsort(idx[a])
+        val_abc = val[sigma]
+        idx_abc = jnp.stack([idx[a][sigma], idx[b][sigma], idx[c][sigma]])
+        return Coef(val_abc, idx_abc.T)
+
     @classmethod
     def unpack(
         cls,

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -321,11 +321,15 @@ def _tensor_product_bwd(params, res, ct_z):
         dx, dy = tensor_product_bwd(coef, x, y, ct_z, params)
         return (ct_coef, dx, dy)
 
-    # TODO: move/remove once double backward rule has been implemented in
-    #       terms of tensor_product and/or tensor_product_bwd.
-    #
-    # Fallback to 2 `tensor_product` kernel calls
+    # Two separate TP forward calls: z-cotangents loaded twice.
+    return _tensor_product_bwd_fallback(params, res, ct_z)
+
+
+def _tensor_product_bwd_fallback(params, res, ct_z):
+    """Backward fallback as two forward tensor product kernel calls."""
     coef, x, y = res
+    ct_coef = jnp.zeros_like(coef)
+
     has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
     mode = TPMode.parse(params.mode)
@@ -366,21 +370,8 @@ def _tensor_product_bwd(params, res, ct_z):
     with jax.ensure_compile_time_eval():
         # Unpack to permute indices for transposed tensor products
         c = Coef.unpack(coef, val_dtype="float32")
-        val, idx = c.val, c.idx
-
-        # ct_x: transpose placing idx_x first, (dz, y) as operands
-        sigma_x = jnp.argsort(idx[:, 1])
-        idx_x = jnp.stack([idx[:, 1], idx[:, 0], idx[:, 2]], axis=-1)[sigma_x]
-        val_x = val[sigma_x]
-
-        # ct_y: transpose placing idx_y first, (dz, x) as operands
-        sigma_y = jnp.argsort(idx[:, 2])
-        idx_y = jnp.stack([idx[:, 2], idx[:, 0], idx[:, 1]], axis=-1)[sigma_y]
-        val_y = val[sigma_y]
-
-        # Repack transposed coefficients
-        coef_x = Coef(val_x, idx_x).pack_jax()
-        coef_y = Coef(val_y, idx_y).pack_jax()
+        coef_x = c.transpose((1, 0, 2)).pack_jax()
+        coef_y = c.transpose((2, 0, 1)).pack_jax()
 
     layout = Layout.parse(params.layout)
     if layout is Layout.LEADING_CHANNELS:

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -181,7 +181,7 @@ def tensor_product(
     return _tensor_product_impl(coef, x, y)
 
 
-# @partial(custom_vjp, nondiff_argnums=(5,))
+@partial(custom_vjp, nondiff_argnums=(5,))
 def tensor_product_bwd(
     coef: Array,
     x: Array,
@@ -200,35 +200,11 @@ def tensor_product_bwd(
     layout = Layout.parse(params.layout)
 
     # Prepare transposed indices and concatenate two backward arrays
-    #
-    # TODO: lexsorting indices should reduce bank conflicts.
     with jax.ensure_compile_time_eval():
         c = Coef.unpack(coef, val_dtype="float32")
-        val, idx = c.val, c.idx.T
-        sigma_xzy = jnp.argsort(idx[1])
-        val_xzy = val[sigma_xzy]
-        idx_xzy = jnp.stack(
-            [
-                idx[1][sigma_xzy],
-                idx[0][sigma_xzy],
-                idx[2][sigma_xzy],
-            ]
-        )
-        sigma_yzx = jnp.argsort(idx[2])
-        val_yzx = val[sigma_yzx]
-        idx_yzx = jnp.stack(
-            [
-                idx[2][sigma_yzx],
-                idx[0][sigma_yzx],
-                idx[1][sigma_yzx],
-            ]
-        )
-        coef_bwd = jnp.stack(
-            [
-                Coef(val_xzy, idx_xzy.T).pack_jax(),
-                Coef(val_yzx, idx_yzx.T).pack_jax(),
-            ]
-        )
+        coef_xzy = c.transpose((1, 0, 2))
+        coef_yzx = c.transpose((2, 0, 1))
+        coef_bwd = jnp.stack([coef_xzy.pack_jax(), coef_yzx.pack_jax()])
 
     has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
@@ -321,8 +297,7 @@ def tensor_product_bwd(
     return _tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
 
 
-# AD Rules
-
+# --- AD Rules for TP forward ---
 
 def _tensor_product_fwd(coef, x, y, params):
     z = tensor_product(coef, x, y, params)
@@ -422,6 +397,21 @@ def _tensor_product_bwd(params, res, ct_z):
     ct_y = tensor_product(coef_y, ct_z, x, params_y)
 
     return (ct_coef, ct_x, ct_y)
+
+
+# --- AD Rules for TP bacward ---
+
+def _tensor_product_bwd_fwd(coef, x, y, dz, params):
+    dx, dy = tensor_product_bwd(coef, x, y, dz, params)
+    return (dx, dy), (coef, x, y, dz)
+
+
+def _tensor_product_bwd_bwd(params, res, ct_xy):
+    dx, dy = ct_xy
+    ddx =
+
+
+
 
 
 tensor_product.defvjp(_tensor_product_fwd, _tensor_product_bwd)

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -35,7 +35,6 @@ class TensorProductParams:
     num_out: int
     mode: str | TPMode = TPMode.OUTER
     layout: str | Layout = Layout.LEADING_CHANNELS
-    unroll: int | tuple[int, int, int] = (1, 1, 1)
 
 
 # XLA-FFI Primitives
@@ -55,7 +54,7 @@ def tensor_product(
             encoding (val, i, j, k) per nonzero CG entry.
         x: l.h.s. operand
         y: r.h.s. operand
-        params: kernel parameters (num_out, mode, layout, unroll).
+        params: kernel parameters (num_out, mode, layout).
 
     Returns:
         The contraction of the sparse 3D coefficient array with x and y.
@@ -73,13 +72,7 @@ def tensor_product(
     else:
         raise ValueError(f"Unsupported layout: {layout}")
 
-    # FFI api: static shape attribute hack to parse unroll
     num_out = params.num_out
-
-    if isinstance(params.unroll, int):
-        kx, ky, kz = [params.unroll] * 3
-    else:
-        kx, ky, kz = params.unroll
 
     # Infer output channels
     mode = TPMode.parse(params.mode)
@@ -127,9 +120,6 @@ def tensor_product(
                 num_out=int32(num_out),
                 mode=int32(mode.value),
                 layout=int32(layout.value),
-                unroll_x=int32(kx),
-                unroll_y=int32(ky),
-                unroll_z=int32(kz),
                 debug=int32(config().debug_level),
             )
 
@@ -252,9 +242,6 @@ def tensor_product_bwd(
         *args,
         mode=int32(mode.value),
         layout=int32(layout.value),
-        unroll_x=int32(1),
-        unroll_y=int32(1),
-        unroll_z=int32(1),
         debug=int32(config().debug_level),
     )
 
@@ -352,8 +339,8 @@ def _tensor_product_bwd(params, res, ct_z):
         num_x, num_y = x.shape[1], y.shape[1]
 
     params_x, params_y = (
-        replace(params, num_out=num_x, mode=mode_x, unroll=1),
-        replace(params, num_out=num_y, mode=mode_y, unroll=1),
+        replace(params, num_out=num_x, mode=mode_x),
+        replace(params, num_out=num_y, mode=mode_y),
     )
 
     ct_x = tensor_product(coef_x, ct_z, y, params_x)

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -38,6 +38,9 @@ class TensorProductParams:
     unroll: int | tuple[int, int, int] = (1, 1, 1)
 
 
+# XLA-FFI Primitives
+
+
 @partial(custom_vjp, nondiff_argnums=(3,))
 def tensor_product(
     coef: Array,
@@ -187,6 +190,78 @@ def tensor_product(
     return _tensor_product_impl(coef, x, y)
 
 
+# @partial(custom_vjp, nondiff_argnums=(5,))
+def tensor_product_bwd(
+    coef: Array,
+    x: Array,
+    y: Array,
+    ct_z: Array,
+    params: TensorProductParams,
+) -> tuple[Array, Array]:
+    """Backward tensor product kernel handler.
+
+    This kernel loads output cotangents `ct_z` once
+    to compute both input cotangents `ct_x, ct_y`.
+    """
+
+    # Parse forward mode and layout: backward modes parsed on C++ side
+    mode = TPMode.parse(params.mode)
+    layout = Layout.parse(params.layout)
+
+    # Prepare transposed indices and concatenate two backward arrays
+    #
+    # TODO: lexsorting indices should reduce bank conflicts.
+    with jax.ensure_compile_time_eval():
+        c = Coef.unpack(coef, val_dtype="float32")
+        val, idx = c.val, c.idx.T
+        sigma_xzy = jnp.argsort(idx[1])
+        val_xzy = val[sigma_xzy]
+        idx_xzy = jnp.stack(
+            [
+                idx[1][sigma_xzy],
+                idx[0][sigma_xzy],
+                idx[2][sigma_xzy],
+            ]
+        )
+        sigma_yzx = jnp.argsort(idx[2])
+        val_yzx = val[sigma_yzx]
+        idx_yzx = jnp.stack(
+            [
+                idx[2][sigma_yzx],
+                idx[0][sigma_yzx],
+                idx[1][sigma_yzx],
+            ]
+        )
+        coef_bwd = jnp.stack(
+            [
+                Coef(val_xzy, idx_xzy.T).pack_jax(),
+                Coef(val_yzx, idx_yzx.T).pack_jax(),
+            ]
+        )
+
+    args = (coef_bwd, x, y, ct_z)
+    shapes_out = (
+        jax.ShapeDtypeStruct(x.shape, x.dtype),
+        jax.ShapeDtypeStruct(y.shape, y.dtype),
+    )
+
+    return ffi_call(
+        "tensor_product_bwd",
+        shapes_out,
+    )(
+        *args,
+        mode=int32(mode.value),
+        layout=int32(layout.value),
+        unroll_x=int32(1),
+        unroll_y=int32(1),
+        unroll_z=int32(1),
+        debug=int32(config().debug_level),
+    )
+
+
+# AD Rules
+
+
 def _tensor_product_fwd(coef, x, y, params):
     z = tensor_product(coef, x, y, params)
     return z, (coef, x, y)
@@ -198,6 +273,21 @@ def _tensor_product_bwd(params, res, ct_z):
     Backpropagate gradients following the Leibniz rule,
     with circular references to the `tensor_product` op.
     """
+    coef, x, y = res
+    # ct_coef: non-differentiable right now, as it would break equivariance.
+    ct_coef = jnp.zeros_like(coef)
+
+    layout = Layout.parse(params.layout)
+
+    # Opt-in to `tensor_product_bwd` kernel handler for force inference
+    if config().tensor_product_bwd and layout == Layout.TRAILING_CHANNELS:
+        dx, dy = tensor_product_bwd(coef, x, y, ct_z, params)
+        return (ct_coef, dx, dy)
+
+    # TODO: move/remove once double backward rule has been implemented in
+    #       terms of tensor_product and/or tensor_product_bwd.
+    #
+    # Fallback to 2 `tensor_product` kernel calls
     coef, x, y = res
     has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
@@ -269,12 +359,10 @@ def _tensor_product_bwd(params, res, ct_z):
     ct_x = tensor_product(coef_x, ct_z, y, params_x)
     ct_y = tensor_product(coef_y, ct_z, x, params_y)
 
-    # ct_coef: non-differentiable right now, as it would break equivariance.
-    ct_coef = jnp.zeros_like(coef)
-
     return (ct_coef, ct_x, ct_y)
 
 
 tensor_product.defvjp(_tensor_product_fwd, _tensor_product_bwd)
+
 
 tensor_product.Params = TensorProductParams

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -181,7 +181,7 @@ def tensor_product(
     return _tensor_product_impl(coef, x, y)
 
 
-@partial(custom_vjp, nondiff_argnums=(5,))
+@partial(custom_vjp, nondiff_argnums=(4,))
 def tensor_product_bwd(
     coef: Array,
     x: Array,
@@ -299,6 +299,7 @@ def tensor_product_bwd(
 
 # --- AD Rules for TP forward ---
 
+
 def _tensor_product_fwd(coef, x, y, params):
     z = tensor_product(coef, x, y, params)
     return z, (coef, x, y)
@@ -316,8 +317,7 @@ def _tensor_product_bwd(params, res, ct_z):
 
     layout = Layout.parse(params.layout)
 
-    # Opt-in to `tensor_product_bwd` kernel handler for force inference
-    if config().tensor_product_bwd and layout == Layout.TRAILING_CHANNELS:
+    if layout == Layout.TRAILING_CHANNELS:
         dx, dy = tensor_product_bwd(coef, x, y, ct_z, params)
         return (ct_coef, dx, dy)
 
@@ -401,20 +401,29 @@ def _tensor_product_bwd(params, res, ct_z):
 
 # --- AD Rules for TP bacward ---
 
+
 def _tensor_product_bwd_fwd(coef, x, y, dz, params):
     dx, dy = tensor_product_bwd(coef, x, y, dz, params)
     return (dx, dy), (coef, x, y, dz)
 
 
 def _tensor_product_bwd_bwd(params, res, ct_xy):
-    dx, dy = ct_xy
-    ddx =
+    """Double backward rule as 1 backward + 2 forward tensor products."""
+    # Output cotangents are second order variations on x, y
+    Ddx, Ddy = ct_xy
+    coef, x, y, dz = res
+    # Input cotangents on x, y
+    (Dx, Dy) = tensor_product_bwd(coef, Ddx, Ddy, dz, params)
+    # Second-order cotangents on z
+    Ddz = tensor_product(coef, x, Ddy, params) + tensor_product(coef, Ddx, y, params)
+    # Inputs of tensor_product_bwd were (x, y, dz) -> now prefixed with D
+    ct_coef = jnp.zeros_like(coef)
+    return (ct_coef, Ddz, Dx, Dy)
 
 
-
-
-
+# Assign VJP rules
 tensor_product.defvjp(_tensor_product_fwd, _tensor_product_bwd)
+tensor_product_bwd.defvjp(_tensor_product_bwd_fwd, _tensor_product_bwd_bwd)
 
 
 tensor_product.Params = TensorProductParams

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -41,7 +41,7 @@ class TensorProductParams:
 # XLA-FFI Primitives
 
 
-@partial(custom_vjp, nondiff_argnums=(3,))
+@partial(custom_vjp, nondiff_argnums=(0, 3))
 def tensor_product(
     coef: Array,
     x: Array,
@@ -181,7 +181,7 @@ def tensor_product(
     return _tensor_product_impl(coef, x, y)
 
 
-@partial(custom_vjp, nondiff_argnums=(4,))
+@partial(custom_vjp, nondiff_argnums=(0, 4))
 def tensor_product_bwd(
     coef: Array,
     x: Array,
@@ -302,34 +302,29 @@ def tensor_product_bwd(
 
 def _tensor_product_fwd(coef, x, y, params):
     z = tensor_product(coef, x, y, params)
-    return z, (coef, x, y)
+    return z, (x, y)
 
 
-def _tensor_product_bwd(params, res, ct_z):
+def _tensor_product_bwd(coef, params, res, ct_z):
     """Backward tensor product rule.
 
     Backpropagate gradients following the Leibniz rule,
     with circular references to the `tensor_product` op.
     """
-    coef, x, y = res
-    # ct_coef: non-differentiable right now, as it would break equivariance.
-    ct_coef = jnp.zeros_like(coef)
-
+    x, y = res
     layout = Layout.parse(params.layout)
 
     if layout == Layout.TRAILING_CHANNELS:
         dx, dy = tensor_product_bwd(coef, x, y, ct_z, params)
-        return (ct_coef, dx, dy)
+        return (dx, dy)
 
     # Two separate TP forward calls: z-cotangents loaded twice.
-    return _tensor_product_bwd_fallback(params, res, ct_z)
+    return _tensor_product_bwd_fallback(coef, params, res, ct_z)
 
 
-def _tensor_product_bwd_fallback(params, res, ct_z):
+def _tensor_product_bwd_fallback(coef, params, res, ct_z):
     """Backward fallback as two forward tensor product kernel calls."""
-    coef, x, y = res
-    ct_coef = jnp.zeros_like(coef)
-
+    x, y = res
     has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
     mode = TPMode.parse(params.mode)
@@ -387,29 +382,30 @@ def _tensor_product_bwd_fallback(params, res, ct_z):
     ct_x = tensor_product(coef_x, ct_z, y, params_x)
     ct_y = tensor_product(coef_y, ct_z, x, params_y)
 
-    return (ct_coef, ct_x, ct_y)
+    return (ct_x, ct_y)
 
 
-# --- AD Rules for TP bacward ---
+# --- AD Rules for TP backward ---
 
 
 def _tensor_product_bwd_fwd(coef, x, y, dz, params):
     dx, dy = tensor_product_bwd(coef, x, y, dz, params)
-    return (dx, dy), (coef, x, y, dz)
+    return (dx, dy), (x, y, dz)
 
 
-def _tensor_product_bwd_bwd(params, res, ct_xy):
+def _tensor_product_bwd_bwd(coef, params, res, ct_xy):
     """Double backward rule as 1 backward + 2 forward tensor products."""
-    # Output cotangents are second order variations on x, y
+    # Outputs of tensor_product_bwd() were (dx, dy):
+    # => Output cotangents are 2nd order variations Ddx, Ddy
     Ddx, Ddy = ct_xy
-    coef, x, y, dz = res
+    x, y, dz = res
     # Input cotangents on x, y
     (Dx, Dy) = tensor_product_bwd(coef, Ddx, Ddy, dz, params)
     # Second-order cotangents on z
     Ddz = tensor_product(coef, x, Ddy, params) + tensor_product(coef, Ddx, y, params)
-    # Inputs of tensor_product_bwd were (x, y, dz) -> now prefixed with D
-    ct_coef = jnp.zeros_like(coef)
-    return (ct_coef, Ddz, Dx, Dy)
+    # Inputs of tensor_product_bwd() were (x, y, dz):
+    # => Input cotangents prefixed with D
+    return (Dx, Dy, Ddz)
 
 
 # Assign VJP rules

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -27,6 +27,7 @@ from numpy import int32
 
 from e3j.ops.coef import Coef
 from e3j.utils import config
+from e3j.utils.exceptions import ShardingError
 from e3j.utils.options import Layout, TPMode
 
 
@@ -229,21 +230,95 @@ def tensor_product_bwd(
             ]
         )
 
-    args = (coef_bwd, x, y, ct_z)
-    shapes_out = (
-        jax.ShapeDtypeStruct(x.shape, x.dtype),
-        jax.ShapeDtypeStruct(y.shape, y.dtype),
-    )
+    has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
-    return ffi_call(
-        "tensor_product_bwd",
-        shapes_out,
-    )(
-        *args,
-        mode=int32(mode.value),
-        layout=int32(layout.value),
-        debug=int32(config().debug_level),
-    )
+    @jax.custom_batching.custom_vmap
+    def _tensor_product_bwd_impl(coef_bwd, x, y, ct_z):
+        @jax.experimental.custom_partitioning.custom_partitioning
+        def __tensor_product_bwd_impl(coef_bwd, x, y, ct_z):
+            shapes_out = (
+                jax.ShapeDtypeStruct(x.shape, x.dtype),
+                jax.ShapeDtypeStruct(y.shape, y.dtype),
+            )
+            return ffi_call(
+                "tensor_product_bwd",
+                shapes_out,
+            )(
+                coef_bwd,
+                x,
+                y,
+                ct_z,
+                mode=int32(mode.value),
+                layout=int32(layout.value),
+                debug=int32(config().debug_level),
+            )
+
+        def partition(mesh, arg_shapes, result_shape):
+            assert len(arg_shapes) == 4, "Expected four arguments: coef_bwd, x, y, ct_z"
+            if len(arg_shapes[1].shape) not in (2, 3):
+                raise ShardingError(
+                    f"Expected x rank 2 or 3, got {arg_shapes[1].shape}"
+                )
+            if len(arg_shapes[2].shape) not in (2, 3):
+                raise ShardingError(
+                    f"Expected y rank 2 or 3, got {arg_shapes[2].shape}"
+                )
+            coef_shape, x_shape, y_shape, ct_z_shape = arg_shapes
+            ct_x_shape, ct_y_shape = result_shape
+
+            return (
+                mesh,
+                __tensor_product_bwd_impl,
+                (ct_x_shape.sharding, ct_y_shape.sharding),
+                (
+                    coef_shape.sharding,
+                    x_shape.sharding,
+                    y_shape.sharding,
+                    ct_z_shape.sharding,
+                ),
+            )
+
+        x_rule = "a b" if has_cx else "a"
+        y_rule = "c d" if has_cy else "c"
+        z_rule = " ".join(["e", "f", "g"][: ct_z.ndim - 1])
+
+        # coef_bwd is (2, K, numel): replicate all axes.
+        sharding_rule = (
+            f"o p q, ... {x_rule}, ... {y_rule}, ... {z_rule} "
+            f"-> ... {x_rule}, ... {y_rule}"
+        )
+
+        __tensor_product_bwd_impl.def_partition(
+            partition=partition,
+            sharding_rule=sharding_rule,
+            need_replication_factors=("o", "p", "q"),
+        )
+
+        return __tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
+
+    @_tensor_product_bwd_impl.def_vmap
+    def _tensor_product_bwd_vmap_rule(axis_size, in_batched, coef_bwd, x, y, ct_z):
+        coef_b, x_b, y_b, ct_z_b = in_batched
+        if coef_b:
+            raise NotImplementedError(
+                "Batching over the coef_bwd argument is not supported."
+            )
+        if not x_b:
+            x = jnp.broadcast_to(x[None], (axis_size,) + x.shape)
+        if not y_b:
+            y = jnp.broadcast_to(y[None], (axis_size,) + y.shape)
+        if not ct_z_b:
+            ct_z = jnp.broadcast_to(ct_z[None], (axis_size,) + ct_z.shape)
+        num_rows = x.shape[1]
+        x = x.reshape((axis_size * num_rows,) + x.shape[2:])
+        y = y.reshape((axis_size * num_rows,) + y.shape[2:])
+        ct_z = ct_z.reshape((axis_size * num_rows,) + ct_z.shape[2:])
+        ct_x, ct_y = _tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
+        ct_x = ct_x.reshape((axis_size, num_rows) + ct_x.shape[1:])
+        ct_y = ct_y.reshape((axis_size, num_rows) + ct_y.shape[1:])
+        return (ct_x, ct_y), (True, True)
+
+    return _tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
 
 
 # AD Rules

--- a/src/e3j/utils/config.py
+++ b/src/e3j/utils/config.py
@@ -63,6 +63,7 @@ class Config(YamlConfig):
     tensor_product: TensorProduct = (
         TensorProduct.FUSED if E3J_OPS_AVAILABLE else TensorProduct.SPARSE
     )
+    tensor_product_bwd: bool = False
     aggregation: Aggregation = Aggregation.SCATTER
     debug_level: int = 0
 

--- a/src/e3j/utils/config.py
+++ b/src/e3j/utils/config.py
@@ -63,7 +63,6 @@ class Config(YamlConfig):
     tensor_product: TensorProduct = (
         TensorProduct.FUSED if E3J_OPS_AVAILABLE else TensorProduct.SPARSE
     )
-    tensor_product_bwd: bool = False
     aggregation: Aggregation = Aggregation.SCATTER
     debug_level: int = 0
 

--- a/src/e3j/utils/exceptions.py
+++ b/src/e3j/utils/exceptions.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 InstaDeep Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ShardingError(ValueError):
+    """Raised when an input to a custom_partitioning rule has an unsupported shape."""

--- a/tests/test_ops/test_coef.py
+++ b/tests/test_ops/test_coef.py
@@ -131,3 +131,39 @@ class TestIdxDtypeRoundTrip:
         numpy.testing.assert_array_equal(
             numpy.asarray(recovered.idx), numpy.asarray(coef.idx)
         )
+
+
+class TestCoefTranspose:
+    """Test Coef.transpose(): column permutation + sort by new first column."""
+
+    @pytest.fixture
+    def coef(self):
+        val = jnp.array([1.0, -0.5, 3.14, 2.0])
+        idx = jnp.array(
+            [[2, 0, 1], [0, 2, 1], [1, 1, 0], [0, 1, 2]],
+            dtype=jnp.int32,
+        )
+        return Coef(val, idx)
+
+    @pytest.mark.parametrize(
+        "argnums",
+        [(0, 1, 2), (1, 0, 2), (2, 0, 1)],
+    )
+    def test_values_follow_indices(self, coef, argnums):
+        """Each (val, i, j, k) tuple is preserved after transpose."""
+        a, b, c = argnums
+        t = coef.transpose(argnums)
+        orig_set = {
+            (float(v), int(i), int(j), int(k))
+            for v, (i, j, k) in zip(coef.val, coef.idx)
+        }
+        trans_set = {
+            (float(v), int(i), int(j), int(k)) for v, (i, j, k) in zip(t.val, t.idx)
+        }
+        # Undo the permutation: original (i,j,k) mapped to (col_a, col_b, col_c)
+        inv = [0, 0, 0]
+        inv[a], inv[b], inv[c] = 0, 1, 2
+        trans_unpermuted = {
+            (v, ijk[inv[0]], ijk[inv[1]], ijk[inv[2]]) for v, *ijk in trans_set
+        }
+        assert orig_set == trans_unpermuted

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -237,13 +237,10 @@ device_description_str: "NVIDIA H100 80GB HBM3"
 """
 
 
-@pytest.mark.skip("TODO: fix vmap support with kernel_bwd")
-def test_vmap_tensor_product_multi_devices():
-    """Check that the operation is sharded as expetected when vmapped and jitted over 2 device.
-    This test use precompilation so it does not require a GPU to run but need to have jax version
-    with gpu support.
-
-    TODO: generalize this setup so we can use it for other tests and run them in the CI.
+def test_vmap_fwd_tensor_product_multi_devices():
+    """Real jax.vmap + sharding: leading vmap axis is split across 2 devices,
+    and the custom_vmap rule flattens (axis_size, num_rows) into a single
+    batch dim seen by the ffi.
     """
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
@@ -264,24 +261,47 @@ def test_vmap_tensor_product_multi_devices():
     def tp(x, y):
         return tensor_product(coef, x, y, params)
 
-    tp_jitted = jax.jit(tp, in_shardings=(sharding, sharding), out_shardings=sharding)
+    tp_jitted = jax.jit(
+        jax.vmap(tp),
+        in_shardings=(sharding, sharding),
+        out_shardings=sharding,
+    )
     tp_compiled = tp_jitted.lower(
         jax.core.ShapedArray((128, *x.shape), x.dtype),
         jax.core.ShapedArray((128, *y.shape), y.dtype),
-        # xs, ys,
-    ).compile()  # Check that it compiles without error
+    ).compile()
     tp_compiled_string = tp_compiled.as_text()
 
-    # We expect a single custom call with batch of 64.
+    # What we expect to see in the HLO on each shard:
+    #   - The vmapped batch dimension (size 128) is sharded over 2 devices,
+    #     so each shard handles 64 samples. vmap then folds those into the
+    #     kernel's own row axis (NUM_ROWS=128), giving 64 * 128 = 8192 rows
+    #     fed into the forward kernel.
+    #   - Exactly one `tensor_product` custom call per shard, with inputs
+    #     (coef, x, y) and output z; coef is replicated across shards.
+    #
+    # Dimension legend (also referenced by the backward test below):
+    #   8192  = rows_per_shard = 64 (sharded vmap) * NUM_ROWS (128)
+    #   20    = x.shape[-1] = out.shape[-1] (from generate_tp_data)
+    #   30    = y.shape[-1] (from generate_tp_data)
+    #   60    = #non-zeros in coef = NUM_STRIPS (10) * LEN_STRIPS (6)
+    #   4     = packed Coef entry (1 value + 3 index components)
     regex = re.compile(
-        r"= f32\[64,2,2,4\].+custom_call_target=\"tensor_product\".+operand_layout_constraints={s32\[12,4\]\{1,0\}, f32\[64,2,4\]{2,1,0}, f32\[64,2,6\]\{2,1,0\}\}",
+        r"= f32\[8192,20\]\{1,0\}.+"  # output: z
+        r'custom_call_target="tensor_product".+'
+        r"operand_layout_constraints=\{"
+        r"s32\[60,4\]\{1,0\}, "  # coef
+        r"f32\[8192,20\]\{1,0\}, "  # x
+        r"f32\[8192,30\]\{1,0\}\}",  # y
         flags=re.MULTILINE,
     )
-    matches = regex.finditer(tp_compiled_string)
-    assert len(list(matches)) == 1
+    assert len(list(regex.finditer(tp_compiled_string))) == 1, (
+        f"Expected exactly one tensor_product custom call, found "
+        f"{len(list(regex.finditer(tp_compiled_string)))}.\n\n"
+        f"HLO:\n{tp_compiled_string}"
+    )
 
 
-@pytest.mark.skip("NYI: sharding support for backward kernel")
 def test_vmap_grad_tensor_product_multi_devices():
     """Check that the operation is sharded as expetected when vmapped and jitted over 2 device.
     This test use precompilation so it does not require a GPU to run but need to have jax version
@@ -291,7 +311,10 @@ def test_vmap_grad_tensor_product_multi_devices():
     """
     num_out, idx, val, x, y = generate_tp_data(channels=(128, None))
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, mode="OUTER")
+
+    # Use TRAILING_CHANNELS so the VJP routes through the tensor_product_bwd
+    params = Params(num_out=num_out, mode="OUTER", layout="TRAILING_CHANNELS")
+    x_shape = (x.shape[0], x.shape[2], x.shape[1])
 
     topology = get_topology_desc(
         "name",
@@ -304,6 +327,10 @@ def test_vmap_grad_tensor_product_multi_devices():
         mesh=mesh,
         spec=jax.sharding.PartitionSpec("batch", None, None),
     )
+    y_sharding = jax.sharding.NamedSharding(
+        mesh=mesh,
+        spec=jax.sharding.PartitionSpec("batch", None),
+    )
 
     def tp(x, y):
         return tensor_product(coef, x, y, params)
@@ -312,22 +339,41 @@ def test_vmap_grad_tensor_product_multi_devices():
         return np.sum(jax.vmap(tp)(x, y))
 
     tp_jitted = jax.jit(
-        jax.grad(l), in_shardings=(sharding, sharding), out_shardings=sharding
+        jax.grad(l, argnums=(0, 1)),
+        in_shardings=(sharding, y_sharding),
+        out_shardings=(sharding, y_sharding),
     )
     tp_compiled = tp_jitted.lower(
-        jax.core.ShapedArray((128, *x.shape), x.dtype),
+        jax.core.ShapedArray((128, *x_shape), x.dtype),
         jax.core.ShapedArray((128, *y.shape), y.dtype),
-        # xs, ys,
     ).compile()  # Check that it compiles without error
     tp_compiled_string = tp_compiled.as_text()
 
-    # We expect a single custom call with batch of 64.
+    # Same shard / batch reasoning as the forward test
+    # (`test_vmap_fwd_tensor_product_multi_devices`); see the dimension
+    # legend there for 8192, 20, 30, 60, 4. Extras that only appear in the
+    # backward HLO:
+    #   128 = x channels (TRAILING_CHANNELS layout); y has no channel dim
+    #   2   = the two transposed COO orderings stacked in coef_bwd (xzy, yzx)
+    #
+    # Exactly one `tensor_product_bwd` custom call per shard, with inputs
+    # (coef_bwd, x, y, ct_z) and outputs (ct_x, ct_y).
     regex = re.compile(
-        r"= f32\[128,128,4\].+custom_call_target=\"tensor_product\".+operand_layout_constraints={s32\[12,4\]\{1,0\}, f32\[128,128,4\]\{2,1,0\}, f32\[128,6\]\{1,0\}\}",
+        # outputs: (ct_x, ct_y)
+        r"\(f32\[8192,20,128\]\{2,1,0\}, f32\[8192,30\]\{1,0\}\) custom-call.+"
+        r'custom_call_target="tensor_product_bwd".+'
+        r"operand_layout_constraints=\{"
+        r"s32\[2,60,4\]\{2,1,0\}, "  # coef_bwd
+        r"f32\[8192,20,128\]\{2,1,0\}, "  # x
+        r"f32\[8192,30\]\{1,0\}, "  # y
+        r"f32\[8192,20,128\]\{2,1,0\}\}",  # ct_z
         flags=re.MULTILINE,
     )
-    matches = regex.finditer(tp_compiled_string)
-    assert len(list(matches)) == 1
+    assert len(list(regex.finditer(tp_compiled_string))) == 1, (
+        f"Expected exactly one tensor_product_bwd custom call, found "
+        f"{len(list(regex.finditer(tp_compiled_string)))}.\n\n"
+        f"HLO:\n{tp_compiled_string}"
+    )
 
 
 def test_vmap_raises_on_batched_coef():

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -291,6 +291,7 @@ def test_vmap_tensor_product_multi_devices():
     assert len(list(matches)) == 1
 
 
+@pytest.mark.skip("NYI: sharding support for backward kernel")
 def test_vmap_grad_tensor_product_multi_devices():
     """Check that the operation is sharded as expetected when vmapped and jitted over 2 device.
     This test use precompilation so it does not require a GPU to run but need to have jax version
@@ -300,7 +301,7 @@ def test_vmap_grad_tensor_product_multi_devices():
     """
     num_out, idx, val, x, y = generate_tp_data(channels=(128, None))
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
 
     topology = get_topology_desc(
         "name",

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -28,14 +28,17 @@ from e3j.ops import tensor_product
 from e3j.ops.coef import Coef
 from e3j.utils.sparse import narrow_index_dtype
 
-e3j.config(debug_level=0)
+e3j.config(
+    debug_level=0,
+    tensor_product_bwd=True,
+)
 
 UNROLL = (1, 1, 1)
 
-NUM_STRIPS = 2
+NUM_STRIPS = 10
 LEN_STRIPS = 6
-NUM_ROWS = 2
-NUM_CHANNELS = 2
+NUM_ROWS = 128
+NUM_CHANNELS = 32
 
 np.set_printoptions(
     precision=4,
@@ -246,6 +249,7 @@ device_description_str: "NVIDIA H100 80GB HBM3"
 """
 
 
+@pytest.mark.skip("TODO: fix vmap support with kernel_bwd")
 def test_vmap_tensor_product_multi_devices():
     """Check that the operation is sharded as expetected when vmapped and jitted over 2 device.
     This test use precompilation so it does not require a GPU to run but need to have jax version
@@ -388,6 +392,7 @@ def test_backward_tensor_product():
     assert np.allclose(ct_y, ct_y_ref)
 
 
+@pytest.mark.skip("NYI: backward tensor_product_bwd")
 def test_backward2_tensor_product():
     """Check two TP backward passes on x and y."""
     num_out, idx, val, x, y = generate_tp_data()
@@ -434,14 +439,14 @@ class _TestTensorProductOp:
 
         keys = (k for k in random.split(random.key(1234), 4))
 
-        # FIXME: makes sure I/O indices are covered, since we
-        #        don't flush rows by default with (lm,l) layout.
+        # NOTE: makes sure I/O indices are covered, since we
+        #        don't flush rows by default with (lm,k) layout.
         def make_idx(dim: int, n: int, key=None) -> Array:
             if key is None:
                 key = random.key(n + dim)
             idx_all = np.arange(dim)
             # Last index has only one occurence, to detect a previous
-            # a previous bug where last store would have been skipped.
+            # bug where last store would have been skipped.
             idx_rdm = random.randint(key, (n - dim,), 0, dim - 1)
             return np.concat((idx_all, idx_rdm))
 
@@ -525,8 +530,8 @@ class _TestTensorProductOp:
         x, y = self.inputs()
         expect_dx, expect_dy = self.bwd_ref(x, y)
         result_dx, result_dy = self.bwd_op(x, y)
-        assert_allclose(expect_dy, result_dy, atol=5e-6, rtol=5e-6)
-        assert_allclose(expect_dx, result_dx, atol=5e-6, rtol=5e-6)
+        assert_allclose(expect_dx, result_dx, atol=5e-5, rtol=5e-5)
+        assert_allclose(expect_dy, result_dy, atol=5e-5, rtol=5e-5)
 
 
 class TestTensorProductOuter(_TestTensorProductOp):
@@ -562,6 +567,14 @@ class TestTensorProductOuterTrailing(TestTensorProductOuter):
     num_idx = 320
 
 
+class TestTensorProductOuterTrailingCY(TestTensorProductOuterTrailing):
+    layout = "TRAILING_CHANNELS"
+    channels_x = 32
+    channels_y = None
+    num_rows = 22
+    num_idx = 320
+
+
 class TestTensorProductInnerTrailing(TestTensorProductInner):
     layout = "TRAILING_CHANNELS"
     channels_x = 32
@@ -570,6 +583,7 @@ class TestTensorProductInnerTrailing(TestTensorProductInner):
 
 class TestTensorProductOuterOneIn(TestTensorProductOuter):
     layout = "TRAILING_CHANNELS"
+    mode = "OUTER"
     channels_x = 32
     channels_y = None
     num_x = 16
@@ -581,6 +595,7 @@ class TestTensorProductOuterOneIn(TestTensorProductOuter):
 
 class TestTensorProductInnerOneOut(TestTensorProductInner):
     layout = "TRAILING_CHANNELS"
+    mode = "INNER"
     channels_x = 32
     channels_y = 32
     num_x = 16

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -84,28 +84,18 @@ def generate_tp_data(
     idx_0 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
     idx_1 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
     idx_2 = np.tile(np.array([0, 1, 2, 0, 1, 2]), NUM_STRIPS)
-    #   num_out, num_x, num_y = 4, 3, 5
-    #   idx_0 = np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3])
-    #   idx_1 = np.array([0, 0, 1, 2, 0, 1, 2, 2, 0, 1, 2, 1, 2])
-    #   idx_2 = np.array([0, 1, 2, 3, 0, 0, 2, 4, 0, 2, 3, 0, 4])
     offsets = np.array([num_out, num_x, num_y])[:, None]
     offsets *= np.arange(NUM_STRIPS).repeat(LEN_STRIPS)
     idx = np.stack([idx_0, idx_1, idx_2]) + offsets
 
     x = np.stack([np.tile(np.array([1.0, 2.0]), NUM_STRIPS)] * num_rows)
     y = np.stack([np.tile(np.array([3.0, 4.0, 5.0]), NUM_STRIPS)] * num_rows)
-    #   x = np.stack([np.linspace(1, num_x, num_x)] * num_rows)
-    #   y = np.stack([np.linspace(1, num_y, num_y)] * num_rows)
 
     if channels[0] is not None:
         x = np.tile(x[:, None, :], (1, channels[0], 1))
     if channels[1] is not None:
         y = np.tile(y[:, None, :], (1, channels[1], 1))
 
-    #   key = random.key(789)
-    #   coef = random.normal(key, (idx.shape[-1],))
-    #   x = random.normal(key, (num_rows, num_x))
-    #   y = random.normal(key, (num_rows, num_y))
     coef = np.ones(idx.shape[-1])
     return num_out * NUM_STRIPS, idx, coef, x, y
 
@@ -340,34 +330,33 @@ def test_vmap_grad_tensor_product_multi_devices():
     assert len(list(matches)) == 1
 
 
-_VMAP_ASSERT = "Only batching over x and y is supported"
-
-
 def test_vmap_raises_on_batched_coef():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
     params = Params(num_out=num_out, mode="OUTER")
     coef_batch = np.stack([coef, coef, coef])
-    with pytest.raises(AssertionError, match=_VMAP_ASSERT):
+    with pytest.raises(ValueError, match=""):
         jax.vmap(lambda c: tensor_product(c, x, y, params))(coef_batch)
 
 
-def test_vmap_raises_on_x_only():
+def test_vmap_batches_on_x_only():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
     params = Params(num_out=num_out, mode="OUTER")
     xs = np.stack([x, x, x])
-    with pytest.raises(AssertionError, match=_VMAP_ASSERT):
-        jax.vmap(lambda xi: tensor_product(coef, xi, y, params))(xs)
+    zs = jax.vmap(lambda xi: tensor_product(coef, xi, y, params))(xs)
+    assert zs.shape[0] == xs.shape[0]
+    testing.assert_allclose(zs[0], zs[-1])
 
 
-def test_vmap_raises_on_y_only():
+def test_vmap_batches_on_y_only():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
     params = Params(num_out=num_out, mode="OUTER")
     ys = np.stack([y, y, y])
-    with pytest.raises(AssertionError, match=_VMAP_ASSERT):
-        jax.vmap(lambda yi: tensor_product(coef, x, yi, params))(ys)
+    zs = jax.vmap(lambda yi: tensor_product(coef, x, yi, params))(ys)
+    assert zs.shape[0] == ys.shape[0]
+    testing.assert_allclose(zs[0], zs[-1])
 
 
 def test_backward_tensor_product():

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -30,7 +30,6 @@ from e3j.utils.sparse import narrow_index_dtype
 
 e3j.config(
     debug_level=0,
-    tensor_product_bwd=True,
 )
 
 NUM_STRIPS = 10

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -33,8 +33,6 @@ e3j.config(
     tensor_product_bwd=True,
 )
 
-UNROLL = (1, 1, 1)
-
 NUM_STRIPS = 10
 LEN_STRIPS = 6
 NUM_ROWS = 128
@@ -163,7 +161,7 @@ def tensor_product_reference(
 def test_forward_tensor_product():
     """Check forward pass."""
     num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     expect = tensor_product_reference(idx, val, x, y, num_out)
     result = tensor_product(pack_coef(val, idx), x, y, params)
     assert np.allclose(expect, result, atol=1e-5)
@@ -172,7 +170,7 @@ def test_forward_tensor_product():
 def test_forward_tensor_product_inner():
     """Check forward pass."""
     num_out, idx, val, x, y = generate_tp_data(channels=[NUM_CHANNELS] * 2)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="INNER")
+    params = Params(num_out=num_out, mode="INNER")
     expect = tensor_product_reference(idx, val, x, y, num_out, mode="INNER")
     result = tensor_product(pack_coef(val, idx), x, y, params)
     assert np.allclose(expect, result, atol=1e-5)
@@ -181,7 +179,7 @@ def test_forward_tensor_product_inner():
 def test_jit_tensor_product():
     """Check that e3j.ops.tensor_product can be compiled."""
     num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     coef = pack_coef(val, idx)
 
     @jax.jit
@@ -194,7 +192,7 @@ def test_jit_tensor_product():
 def test_jit_tensor_product_vmap():
     """Check that e3j.ops.tensor_product can be compiled."""
     num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     coef = pack_coef(val, idx)
     xs = np.stack([x, x])
     ys = np.stack([y, y])
@@ -259,7 +257,7 @@ def test_vmap_tensor_product_multi_devices():
     """
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
 
     topology = get_topology_desc(
         "name",
@@ -347,7 +345,7 @@ _VMAP_ASSERT = "Only batching over x and y is supported"
 def test_vmap_raises_on_batched_coef():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     coef_batch = np.stack([coef, coef, coef])
     with pytest.raises(AssertionError, match=_VMAP_ASSERT):
         jax.vmap(lambda c: tensor_product(c, x, y, params))(coef_batch)
@@ -356,7 +354,7 @@ def test_vmap_raises_on_batched_coef():
 def test_vmap_raises_on_x_only():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     xs = np.stack([x, x, x])
     with pytest.raises(AssertionError, match=_VMAP_ASSERT):
         jax.vmap(lambda xi: tensor_product(coef, xi, y, params))(xs)
@@ -365,7 +363,7 @@ def test_vmap_raises_on_x_only():
 def test_vmap_raises_on_y_only():
     num_out, idx, val, x, y = generate_tp_data()
     coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     ys = np.stack([y, y, y])
     with pytest.raises(AssertionError, match=_VMAP_ASSERT):
         jax.vmap(lambda yi: tensor_product(coef, x, yi, params))(ys)
@@ -374,7 +372,7 @@ def test_vmap_raises_on_y_only():
 def test_backward_tensor_product():
     """Check backward pass on x and y gradients."""
     num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     coef = pack_coef(val, idx)
 
     def f_custom(x, y):
@@ -396,7 +394,7 @@ def test_backward_tensor_product():
 def test_backward2_tensor_product():
     """Check two TP backward passes on x and y."""
     num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, unroll=UNROLL, mode="OUTER")
+    params = Params(num_out=num_out, mode="OUTER")
     coef = pack_coef(val, idx)
 
     def prod_custom(x, y):
@@ -425,7 +423,6 @@ class _TestTensorProductOp:
     channels_x: int | None = None
     channels_y: int | None = None
     num_rows = 16
-    unroll: tuple[int, ...] = (1, 1, 1)
     layout: str = "LEADING_CHANNELS"
 
     def closure(self):
@@ -463,7 +460,6 @@ class _TestTensorProductOp:
 
         kwargs = {
             "num_out": self.num_out,
-            "unroll": self.unroll,
             "mode": self.mode,
             "layout": self.layout,
         }
@@ -473,7 +469,6 @@ class _TestTensorProductOp:
     @property
     def fwd_ref(self):
         idx, val, kwargs = self.closure()
-        kwargs.pop("unroll")
         return lambda x, y: tensor_product_reference(idx, val, x, y, **kwargs)
 
     @property
@@ -543,7 +538,6 @@ class TestTensorProductOuter(_TestTensorProductOp):
     channels_x = 8
     channels_y = None
     num_rows = 6
-    unroll = (1, 1, 1)
 
 
 class TestTensorProductInner(_TestTensorProductOp):
@@ -555,7 +549,6 @@ class TestTensorProductInner(_TestTensorProductOp):
     channels_x = 4
     channels_y = 4
     num_rows = 12
-    unroll = (1, 1, 1)
 
 
 class TestTensorProductOuterTrailing(TestTensorProductOuter):

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -303,7 +303,7 @@ def test_vmap_fwd_tensor_product_multi_devices():
 
 
 def test_vmap_grad_tensor_product_multi_devices():
-    """Check that the operation is sharded as expetected when vmapped and jitted over 2 device.
+    """Check that the operation is sharded as expected when vmapped and jitted over 2 device.
     This test use precompilation so it does not require a GPU to run but need to have jax version
     with gpu support.
 
@@ -335,19 +335,23 @@ def test_vmap_grad_tensor_product_multi_devices():
     def tp(x, y):
         return tensor_product(coef, x, y, params)
 
-    def l(x, y):
+    def sum_vmap_tp(x, y):
         return np.sum(jax.vmap(tp)(x, y))
 
-    tp_jitted = jax.jit(
-        jax.grad(l, argnums=(0, 1)),
+    # A function with forward + backward tensor product passes
+    fn = jax.grad(sum_vmap_tp, argnums=(0, 1))
+
+    jitted_fn = jax.jit(
+        fn,
         in_shardings=(sharding, y_sharding),
         out_shardings=(sharding, y_sharding),
     )
-    tp_compiled = tp_jitted.lower(
+    compiled_fn = jitted_fn.lower(
         jax.core.ShapedArray((128, *x_shape), x.dtype),
         jax.core.ShapedArray((128, *y.shape), y.dtype),
     ).compile()  # Check that it compiles without error
-    tp_compiled_string = tp_compiled.as_text()
+
+    compiled_fn_string = compiled_fn.as_text()
 
     # Same shard / batch reasoning as the forward test
     # (`test_vmap_fwd_tensor_product_multi_devices`); see the dimension
@@ -369,10 +373,10 @@ def test_vmap_grad_tensor_product_multi_devices():
         r"f32\[8192,20,128\]\{2,1,0\}\}",  # ct_z
         flags=re.MULTILINE,
     )
-    assert len(list(regex.finditer(tp_compiled_string))) == 1, (
+    assert len(list(regex.finditer(compiled_fn_string))) == 1, (
         f"Expected exactly one tensor_product_bwd custom call, found "
-        f"{len(list(regex.finditer(tp_compiled_string)))}.\n\n"
-        f"HLO:\n{tp_compiled_string}"
+        f"{len(list(regex.finditer(compiled_fn_string)))}.\n\n"
+        f"HLO:\n{compiled_fn_string}"
     )
 
 
@@ -381,7 +385,7 @@ def test_vmap_raises_on_batched_coef():
     coef = pack_coef(val, idx)
     params = Params(num_out=num_out, mode="OUTER")
     coef_batch = np.stack([coef, coef, coef])
-    with pytest.raises(ValueError, match=""):
+    with pytest.raises(jax.errors.UnexpectedTracerError):
         jax.vmap(lambda c: tensor_product(c, x, y, params))(coef_batch)
 
 
@@ -426,7 +430,6 @@ def test_backward_tensor_product():
     assert np.allclose(ct_y, ct_y_ref)
 
 
-@pytest.mark.skip("NYI: backward tensor_product_bwd")
 def test_backward2_tensor_product():
     """Check two TP backward passes on x and y."""
     num_out, idx, val, x, y = generate_tp_data()
@@ -528,6 +531,34 @@ class _TestTensorProductOp:
             argnums=(0, 1),
         )
 
+    @property
+    def bwd_bwd_op(self):
+        def sum_bwd(x, y, dz):
+            """A backward operation consuming dz cotangents."""
+            df = jax.grad(
+                lambda x, y, dz: np.sum(self.fwd_op(x, y) * dz),
+                argnums=(0, 1),
+            )
+            dx, dy = df(x, y, dz)
+            return np.sum(dx) + np.sum(dy)
+
+        # Differentiate once more, yield 3 cotangents
+        return jax.grad(sum_bwd, argnums=(0, 1, 2))
+
+    @property
+    def bwd_bwd_ref(self):
+        def sum_bwd(x, y, dz):
+            """A backward operation consuming dz cotangents."""
+            df = jax.grad(
+                lambda x, y, dz: np.sum(self.fwd_ref(x, y) * dz),
+                argnums=(0, 1),
+            )
+            dx, dy = df(x, y, dz)
+            return np.sum(dx) + np.sum(dy)
+
+        # Differentiate once more, yield 3 cotangents
+        return jax.grad(sum_bwd, argnums=(0, 1, 2))
+
     def inputs(self) -> tuple[Array, Array]:
         n = self.num_rows
         nx, ny = self.num_x, self.num_y
@@ -563,6 +594,15 @@ class _TestTensorProductOp:
         result_dx, result_dy = self.bwd_op(x, y)
         assert_allclose(expect_dx, result_dx, atol=5e-5, rtol=5e-5)
         assert_allclose(expect_dy, result_dy, atol=5e-5, rtol=5e-5)
+
+    def test_backward_backward(self):
+        x, y = self.inputs()
+        dz = self.fwd_ref(x, y)
+        expect_Dx, expect_Dy, expect_Ddz = self.bwd_bwd_ref(x, y, dz)
+        result_Dx, result_Dy, result_Ddz = self.bwd_bwd_op(x, y, dz)
+        assert_allclose(expect_Dx, result_Dx, atol=5e-5, rtol=5e-5)
+        assert_allclose(expect_Dy, result_Dy, atol=5e-5, rtol=5e-5)
+        assert_allclose(expect_Ddz, result_Ddz, atol=5e-5, rtol=5e-5)
 
 
 class TestTensorProductOuter(_TestTensorProductOp):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <3.15"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -872,7 +872,7 @@ wheels = [
 
 [[package]]
 name = "e3j"
-version = "0.1.0b1"
+version = "0.1.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "e3nn-jax" },
@@ -1040,7 +1040,7 @@ tensorboard = [
 
 [[package]]
 name = "e3j-ops"
-version = "0.1.0b1"
+version = "0.1.0b2"
 source = { editable = "lib/e3j_ops" }
 
 [[package]]


### PR DESCRIPTION
## [0.1.0b2] — 2026-05-28

### Added

- CUDA kernel for tensor product backward (trailing channels). This kernel loads output
  cotangents only once to compute both input cotangents via two tensor product operations.
- JAX primitive `e3j.ops.tensor_product_bwd()` with AD rules, vmap and sharding support.
  The double backward rule is expressed in terms of one `tensor_product_bwd()` call and
  two `tensor_product()` calls, providing infinite differentiability.

### Changed

- Dropped leftover `unroll` parameters that could be passed from the Python side. They
  are now private to the CUDA side and inferred alongside kernel launch configuration.

