### PR TITLE
Release/v0.1.0b3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com).
 
+## [0.1.0b3] — 2026-06-10
+
+### Fixed
+
+- Fused tensor product backward (`tensor_product_bwd()`) left gradient rows for
+  uncoupled input coordinates uninitialized (garbage / NaN) instead of zero. The
+  kernel only writes coordinates present in the Clebsch-Gordan coefficients, so
+  coordinates absent from them — common when the forward output is truncated,
+  e.g. symmetric contraction in MAP mode — were never written, diverging from the
+  SPARSE/DENSE autodiff gradients. Those rows are now zeroed explicitly after the
+  kernel.
+
+### Changed
+
+- Tensor product forward and backward CUDA kernels now share a single
+  `CuArray2D.load()` / `.store()` abstraction for global↔shared memory copies,
+  replacing the per-operand branching between contiguous and strided variants.
+  Loads use LDGSTS (asynchronous copy via pipeline primitives) and stride through
+  source channels automatically when they exceed the shared-memory budget.
+
 ## [0.1.0b2] — 2026-05-28
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@
 #
 ###########################################################
 
+SHELL=/bin/bash
+
 #### G++ ##################################################
 
 # CXX => implicit C++ compilation rules [1]
@@ -135,7 +137,11 @@ test_%: bin/test_%
 cutest: $(CU_TEST)
 
 pytest:
-	uv run pytest -rfps -m "e3j_ops" tests/test_ops
+	if [[ -n "$(k)" ]]; then\
+		uv run pytest -v -m "e3j_ops" -k $(k) tests/test_ops;\
+	else\
+		uv run pytest -v -m "e3j_ops" tests/test_ops/test_tensor_product_op.py;\
+	fi
 
 test: $(CU_TEST) pytest
 

--- a/lib/e3j_ops/cuda/array.cuh
+++ b/lib/e3j_ops/cuda/array.cuh
@@ -17,6 +17,7 @@
 #define _E3J_ARRAY_H_
 
 #include <cstdint>
+#include "cuda/utils.cuh"
 
 namespace e3j {
 
@@ -45,6 +46,30 @@ struct CuArray2D {
     __device__ T& operator [] (unsigned int pos) {
         return data[pos];
     }
+
+    template<int N=1>
+    __device__ void load(CuArray2D<const T> src) {
+        if (shape[1] == src.shape[1])
+            utils::copy_pipe<N>(
+                data, src.data, src.size()
+            );
+        else
+            utils::copy_pipe_strided(
+                data, src.data, src.shape[0], shape[1], src.shape[1]
+            );
+    }
+
+    __device__ void store(CuArray2D<T> dst) {
+        if (shape[1] == dst.shape[1])
+            utils::copy(
+                dst.data, data, size()
+            );
+        else
+            utils::copy_strided(
+                dst.data, data, shape[0], dst.shape[1], shape[1]
+            );
+    }
+
 };
 
 

--- a/lib/e3j_ops/cuda/array.cuh
+++ b/lib/e3j_ops/cuda/array.cuh
@@ -21,6 +21,16 @@
 
 namespace e3j {
 
+/****************************************************************
+ *  CUDA arrays aware of their trailing 2D shapes.
+ *
+ *  Device functions can often be expressed in terms of `CuArray2D`
+ *  with concise signatures, since it contains the necessary problem
+ *  sizes to work on a single batch.
+ *
+ *  Since the leading batch axis is usually shared, it is passed as
+ *  a separate single register.
+ ****************************************************************/
 template <typename T>
 struct CuArray2D {
     T* data;
@@ -47,6 +57,8 @@ struct CuArray2D {
         return data[pos];
     }
 
+    // Load a 2D array to shared memory (LDGSTS, pipeline primitives API).
+    // Supports striding through source channels when too large to fit in SMEM.
     template<int N=1>
     __device__ void load(CuArray2D<const T> src) {
         if (shape[1] == src.shape[1])
@@ -59,6 +71,7 @@ struct CuArray2D {
             );
     }
 
+    // Store a 2D array to global memory (inline copy with striding support).
     __device__ void store(CuArray2D<T> dst) {
         if (shape[1] == dst.shape[1])
             utils::copy(

--- a/lib/e3j_ops/cuda/tensor_product/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product/trailing_channels.cuh
@@ -30,7 +30,6 @@ namespace tensor_product {
 namespace trailing_channels {
 
     using utils::copy_pipe;
-    using utils::copy_pipe_strided;
     using utils::wait_pipe;
     using utils::fill;
     using utils::DeviceProperties;
@@ -385,7 +384,6 @@ __global__ void kernel(
     constexpr bool accumulate = (kMode == Mode::INNER) && strided;
 
     // Shared memory layout: [ coef | x | y | z ]
-    // smem_base is 16-byte aligned (hardware guarantee ≥128 B).
     extern __shared__ __align__(16) char smem__[];
     char* smem_ = reinterpret_cast<char*>(smem__);
     Buffers smem = Buffers::init(x, y, z, unroll);
@@ -442,23 +440,11 @@ __global__ void kernel(
         for (int s = 0; s < num_strides; s++) {
 
             // Load x and y into SMEM via pipeline primitives (LDGSTS).
-            if (x.shape[1] > unroll.x)
-                copy_pipe_strided(smem.lhs.data, x_s.data, num_x, unroll.x, x.shape[1]);
+            smem.lhs.load<N>(x_s);
+            if constexpr (kMode == Mode::OUTER)
+                smem.rhs.load<1>(y_s);
             else
-                copy_pipe<N>(smem.lhs.data, x_s.data, smem.lhs.size());
-
-            if (y.shape[1] > unroll.y)
-                copy_pipe_strided(smem.rhs.data, y_s.data, num_y, unroll.y, y.shape[1]);
-            else if constexpr (N > 1) {
-                // Vectorized copy requires the source to be N*sizeof(T)-byte aligned.
-                // The per-block y pointer advances by num_y*channels_y floats, so
-                // alignment is preserved only when that stride is a multiple of N.
-                if (smem.rhs.size() % N == 0)
-                    copy_pipe<N>(smem.rhs.data, y_s.data, smem.rhs.size());
-                else
-                    copy_pipe<1>(smem.rhs.data, y_s.data, smem.rhs.size());
-            } else
-                copy_pipe<1>(smem.rhs.data, y_s.data, smem.rhs.size());
+                smem.rhs.load<N>(y_s);
 
             __pipeline_commit();
             wait_pipe();

--- a/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
+++ b/lib/e3j_ops/cuda/tensor_product_bwd/trailing_channels.cuh
@@ -35,10 +35,8 @@ namespace tensor_product {
 
 namespace trailing_channels {
 
-using utils::copy;
 using utils::wait_pipe;
 using utils::copy_pipe;
-using utils::copy_pipe_strided;
 using utils::fill;
 using utils::DeviceProperties;
 
@@ -176,39 +174,27 @@ __global__ void kernel_bwd(
         //=== Channel stride loop ===
         for (int s = 0; s < num_strides; s++) {
 
-            // Load dz and y — needed by the dx pass.
-            // Broadcast operands (n_channels <= unroll) are contiguous:
-            // use copy_pipe<1> to avoid 16 B alignment requirement.
-            if (cz > unroll.z)
-                copy_pipe_strided(smem.dz.data, dz_s.data, dz.shape[0], unroll.z, cz);
-            else
-                copy_pipe<N>(smem.dz.data, dz_s.data, smem.dz.size());
-
-            if (cy > unroll.y)
-                copy_pipe_strided(smem.y.data, y_s.data, y.shape[0], unroll.y, cy);
-            else
-                copy_pipe<1>(smem.y.data, y_s.data, smem.y.size());
+            // Load dz and y
+            smem.dz.load<N>(dz_s);
+            smem.y.load<1>(y_s);
             __pipeline_commit();
 
-            // Issue x load — overlaps with the dx otimes below.
-            if (cx > unroll.x)
-                copy_pipe_strided(smem.x.data, x_s.data, x.shape[0], unroll.x, cx);
-            else
-                copy_pipe<N>(smem.x.data, x_s.data, smem.x.size());
+            // Issue x load
+            smem.x.load<N>(x_s);
             __pipeline_commit();
 
-            // Drain dz + y (pipeline group 0).
+            // Drain dz + y
             wait_pipe<1>();
 
-            // Compute dx: reads dz + y (complete), does not touch smem.x.
+            // Compute dx = otimes(dz, y)
             otimes<Idx,Val,dxMode, N, inner_dx>(
                 coef_dx, coef_range_dx, smem.dz, smem.y, dx_s, k_dx, smem.dxy
             );
 
-            // Drain x (pipeline group 1).
+            // Drain x
             wait_pipe();
 
-            // Compute dy: reads dz + x (now complete).
+            // Compute dy = otimes(dz, x)
             otimes<Idx,Val,dyMode, N, inner_dy>(
                 coef_dy, coef_range_dy, smem.dz, smem.x, dy_s, k_dy, smem.dxy
             );
@@ -224,7 +210,7 @@ __global__ void kernel_bwd(
 
         }//=== Channel stride loop ===
 
-        // Flush INNER scratch to GMEM after all strides
+        // Reduce INNER output buffers before STG
         if constexpr (inner_dx) {
             for (unsigned int i = threadIdx.x; i < dx.shape[0]; i += blockDim.x) {
                 Val sum = 0;

--- a/lib/e3j_ops/cuda/utils.cuh
+++ b/lib/e3j_ops/cuda/utils.cuh
@@ -229,12 +229,11 @@ __device__ void copy_strided(
     T* dst,
     const T* src,
     const int num_rows,
-    const int width,
-    const int stride_dst,
-    const int stride_src
+    const int stride,
+    const int width
 ) {
     for (int r = threadIdx.y; r < num_rows; r += blockDim.y) {
-        copy(&dst[r * stride_dst], &src[r * stride_src], width);
+        copy(&dst[r * stride], &src[r * width], width);
     }
 }
 

--- a/lib/e3j_ops/cuda/utils.cuh
+++ b/lib/e3j_ops/cuda/utils.cuh
@@ -188,9 +188,9 @@ template <typename T>
 __device__ void copy_pipe_strided (
     T* dst,
     const T* src,
-    const int num_rows,
-    const int width,
-    const int stride
+    unsigned int num_rows,
+    unsigned int width,
+    unsigned int stride
 ) {
     constexpr int CHUNK = 16 / sizeof(T);
     int tid = threadIdx.x + threadIdx.y * blockDim.x;

--- a/lib/e3j_ops/pyproject.toml
+++ b/lib/e3j_ops/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "e3j_ops"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Fast Euclid equivariant operations for JAX"
 authors = [
     { name="Olivier Peltre", email="o.peltre@instadeep.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "e3j"
-version = "0.1.0b2"
+version = "0.1.0b3"
 description = "Fast Euclid equivariant operations for JAX"
 authors = [
     { name="Olivier Peltre", email="o.peltre@instadeep.com" },
@@ -24,7 +24,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ops = [
-    "e3j_ops == 0.1.0b2",
+    "e3j_ops == 0.1.0b3",
     "pybind11 >= 2.13.6"
 ]
 

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -182,20 +182,11 @@ def tensor_product(
 
 
 def _zero_gap_rows(grad: Array, written: np.ndarray, layout: Layout) -> Array:
-    """Zero ``grad`` rows the fused kernel skipped (coords absent from ``written``).
+    """Zero ``grad`` rows skipped by the fused backward kernel.
 
-    The backward kernel only writes output coordinates that appear in the
-    coefficients -- ``written`` is the set of coordinates this pass writes (column
-    0 of the transposed coef). Input coordinates with no surviving coupling, common
-    once the forward output is truncated (e.g. symmetric contraction in MAP mode),
-    are skipped, so the freshly allocated ``grad`` reads back as uninitialized
-    memory (garbage / NaN) there. Their gradient is exactly 0, so we overwrite
-    those rows -- matching the SPARSE/DENSE autodiff gradients.
-
-    ``written`` is a concrete numpy array (extracted inside ensure_compile_time_eval),
-    so this lowers to a constant-index scatter XLA applies in place over only the gap
-    rows -- not a full-buffer pass. The coordinate (lm) axis is last, unless a channel
-    axis trails it (trailing channels), as in `TensorProduct.sparse_eval`.
+    Only coordinates present in ``written`` are written by the backward pass;
+    the rest retain uninitialized memory. Their gradient is exactly zero, so we
+    zero them explicitly to match SPARSE/DENSE autodiff.
     """
     channels_trail = layout == Layout.TRAILING_CHANNELS and grad.ndim > 2
     n_coords = grad.shape[-2 if channels_trail else -1]

--- a/src/e3j/ops/tensor_product.py
+++ b/src/e3j/ops/tensor_product.py
@@ -181,6 +181,31 @@ def tensor_product(
     return _tensor_product_impl(coef, x, y)
 
 
+def _zero_gap_rows(grad: Array, written: np.ndarray, layout: Layout) -> Array:
+    """Zero ``grad`` rows the fused kernel skipped (coords absent from ``written``).
+
+    The backward kernel only writes output coordinates that appear in the
+    coefficients -- ``written`` is the set of coordinates this pass writes (column
+    0 of the transposed coef). Input coordinates with no surviving coupling, common
+    once the forward output is truncated (e.g. symmetric contraction in MAP mode),
+    are skipped, so the freshly allocated ``grad`` reads back as uninitialized
+    memory (garbage / NaN) there. Their gradient is exactly 0, so we overwrite
+    those rows -- matching the SPARSE/DENSE autodiff gradients.
+
+    ``written`` is a concrete numpy array (extracted inside ensure_compile_time_eval),
+    so this lowers to a constant-index scatter XLA applies in place over only the gap
+    rows -- not a full-buffer pass. The coordinate (lm) axis is last, unless a channel
+    axis trails it (trailing channels), as in `TensorProduct.sparse_eval`.
+    """
+    channels_trail = layout == Layout.TRAILING_CHANNELS and grad.ndim > 2
+    n_coords = grad.shape[-2 if channels_trail else -1]
+    gaps = sorted(set(range(n_coords)) - set(written.flat))
+    if not gaps:
+        return grad
+    g = jnp.asarray(gaps)
+    return (grad.at[..., g, :] if channels_trail else grad.at[..., g]).set(0.0)
+
+
 @partial(custom_vjp, nondiff_argnums=(0, 4))
 def tensor_product_bwd(
     coef: Array,
@@ -199,12 +224,16 @@ def tensor_product_bwd(
     mode = TPMode.parse(params.mode)
     layout = Layout.parse(params.layout)
 
-    # Prepare transposed indices and concatenate two backward arrays
+    # Prepare transposed indices and concatenate two backward arrays.
+    # coef_xzy / coef_yzx are the dx / dy passes; their column 0 (the output
+    # index) is the set of coordinates each pass writes -- used to zero gaps.
     with jax.ensure_compile_time_eval():
         c = Coef.unpack(coef, val_dtype="float32")
         coef_xzy = c.transpose((1, 0, 2))
         coef_yzx = c.transpose((2, 0, 1))
         coef_bwd = jnp.stack([coef_xzy.pack_jax(), coef_yzx.pack_jax()])
+        written_x = np.asarray(coef_xzy.idx[:, 0])
+        written_y = np.asarray(coef_yzx.idx[:, 0])
 
     has_cx, has_cy = x.ndim > 2, y.ndim > 2
 
@@ -294,7 +323,10 @@ def tensor_product_bwd(
         ct_y = ct_y.reshape((axis_size, num_rows) + ct_y.shape[1:])
         return (ct_x, ct_y), (True, True)
 
-    return _tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
+    ct_x, ct_y = _tensor_product_bwd_impl(coef_bwd, x, y, ct_z)
+    ct_x = _zero_gap_rows(ct_x, written_x, layout)
+    ct_y = _zero_gap_rows(ct_y, written_y, layout)
+    return ct_x, ct_y
 
 
 # --- AD Rules for TP forward ---

--- a/tests/test_ops/test_tensor_product_jax_transforms.py
+++ b/tests/test_ops/test_tensor_product_jax_transforms.py
@@ -1,0 +1,432 @@
+# Copyright (c) 2026 InstaDeep Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""JAX integration tests for tensor_product: jit, vmap, sharding, AD."""
+
+import re
+
+import jax
+import jax.numpy as np
+import numpy.testing as testing
+import pytest
+from jax import Array
+from jax.experimental.topologies import get_topology_desc
+
+import e3j
+from e3j.ops import TensorProductParams as Params
+from e3j.ops import tensor_product
+from e3j.ops.coef import Coef
+
+e3j.config(
+    debug_level=0,
+)
+
+NUM_STRIPS = 10
+LEN_STRIPS = 6
+NUM_ROWS = 128
+NUM_CHANNELS = 32
+
+
+def pack_coef(val, idx, val_dtype="float32", idx_dtype="int32"):
+    """Pack (nnz,) values + (3, nnz) COO indices into an opaque JAX array."""
+    return Coef(val, idx.T, val_dtype=val_dtype, idx_dtype=idx_dtype).pack_jax()
+
+
+def generate_tp_data(
+    channels: tuple[int | None, int | None] = (None, None),
+) -> tuple[int, Array, Array, Array, Array]:
+    """
+    Generate common test inputs for the forward and backward tests.
+
+    Returns:
+        num_out: target space dimension.
+        idx: A 2D index array of leading dimension 3.
+        coef: A 1D value vector of length `idx.shape[-1]`.
+        x: Array of shape `(num_rows, num_x)`, or `(num_rows, channels[0], num_x)`.
+        y: Array of shape `(num_rows, num_y)`, or `(num_rows, channels[1], num_y)`.
+    """
+    num_rows = NUM_ROWS
+
+    # lexsorted indices
+    num_out, num_x, num_y = 2, 2, 3
+    idx_0 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
+    idx_1 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
+    idx_2 = np.tile(np.array([0, 1, 2, 0, 1, 2]), NUM_STRIPS)
+    offsets = np.array([num_out, num_x, num_y])[:, None]
+    offsets *= np.arange(NUM_STRIPS).repeat(LEN_STRIPS)
+    idx = np.stack([idx_0, idx_1, idx_2]) + offsets
+
+    x = np.stack([np.tile(np.array([1.0, 2.0]), NUM_STRIPS)] * num_rows)
+    y = np.stack([np.tile(np.array([3.0, 4.0, 5.0]), NUM_STRIPS)] * num_rows)
+
+    if channels[0] is not None:
+        x = np.tile(x[:, None, :], (1, channels[0], 1))
+    if channels[1] is not None:
+        y = np.tile(y[:, None, :], (1, channels[1], 1))
+
+    coef = np.ones(idx.shape[-1])
+    return num_out * NUM_STRIPS, idx, coef, x, y
+
+
+def tensor_product_reference(
+    idx, coef, x, y, num_out, mode="OUTER", layout="LEADING_CHANNELS"
+):
+    """Reference tensor_product implementation."""
+
+    if layout == "TRAILING_CHANNELS":
+        x_t = x if x.ndim < 3 else np.matrix_transpose(x)
+        y_t = y if y.ndim < 3 else np.matrix_transpose(y)
+        z_t = tensor_product_reference(idx, coef, x_t, y_t, num_out, mode)
+        if z_t.ndim < 3:
+            return z_t
+        return np.matrix_transpose(z_t)
+
+    n_rows = x.shape[0]
+
+    if mode == "MAP":
+        shape_out = (n_rows, x.shape[1], num_out)
+        out = np.zeros(shape_out, dtype=x.dtype)
+        cxy = coef * x[..., idx[1]] * y[..., idx[2]]
+        return out.at[..., idx[0]].add(cxy)
+
+    if mode == "OUTER":
+        has_cx, has_cy = x.ndim > 2, y.ndim > 2
+
+        if not (has_cx or has_cy):
+            shape_out = (n_rows, num_out)
+
+        elif has_cx:
+            shape_out = (n_rows, x.shape[1], num_out)
+            y = y[:, None]
+
+        elif has_cy:
+            shape_out = (n_rows, y.shape[1], num_out)
+            x = x[:, None]
+
+        out = np.zeros(shape_out, dtype=x.dtype)
+        cxy = coef * x[..., idx[1]] * y[..., idx[2]]
+        return out.at[..., idx[0]].add(cxy)
+
+    if mode == "INNER":
+        assert x.shape[-2] == y.shape[-2]
+        shape_out = (n_rows, num_out)
+        out = np.zeros(shape_out, dtype=x.dtype)
+        cxy = coef * x[..., idx[1]] * y[..., idx[2]]
+        sum_cxy = np.sum(cxy, axis=-2)
+        return out.at[..., idx[0]].add(sum_cxy)
+
+
+def test_forward_tensor_product():
+    """Check forward pass."""
+    num_out, idx, val, x, y = generate_tp_data()
+    params = Params(num_out=num_out, mode="OUTER")
+    expect = tensor_product_reference(idx, val, x, y, num_out)
+    result = tensor_product(pack_coef(val, idx), x, y, params)
+    assert np.allclose(expect, result, atol=1e-5)
+
+
+def test_forward_tensor_product_inner():
+    """Check forward pass."""
+    num_out, idx, val, x, y = generate_tp_data(channels=[NUM_CHANNELS] * 2)
+    params = Params(num_out=num_out, mode="INNER")
+    expect = tensor_product_reference(idx, val, x, y, num_out, mode="INNER")
+    result = tensor_product(pack_coef(val, idx), x, y, params)
+    assert np.allclose(expect, result, atol=1e-5)
+
+
+def test_jit_tensor_product():
+    """Check that e3j.ops.tensor_product can be compiled."""
+    num_out, idx, val, x, y = generate_tp_data()
+    params = Params(num_out=num_out, mode="OUTER")
+    coef = pack_coef(val, idx)
+
+    @jax.jit
+    def tp(x, y, num_out):
+        return tensor_product(coef, x, y, params)
+
+    assert tp(x, y, num_out).shape[-1] == num_out
+
+
+def test_jit_tensor_product_vmap():
+    """Check that e3j.ops.tensor_product can be compiled."""
+    num_out, idx, val, x, y = generate_tp_data()
+    params = Params(num_out=num_out, mode="OUTER")
+    coef = pack_coef(val, idx)
+    xs = np.stack([x, x])
+    ys = np.stack([y, y])
+
+    def tp(x, y):
+        return tensor_product(coef, x, y, params)
+
+    out_normal = tp(x, y)
+    out_vmap = jax.vmap(tp)(xs, ys)
+    assert out_normal.shape[-1] == num_out
+    assert out_vmap.shape[-1] == num_out
+    assert out_vmap[0].shape == out_normal.shape
+    assert np.allclose(out_vmap[0], out_normal, atol=1e-5)
+    assert np.allclose(out_vmap[1], out_normal, atol=1e-5)
+
+
+# Target config to simulate H100 GPU for testing
+h100_gpu_target_config = """
+gpu_device_info {
+  threads_per_block_limit: 1024
+  threads_per_warp: 32
+  shared_memory_per_block: 49152
+  shared_memory_per_core: 233472
+  threads_per_core_limit: 2048
+  core_count: 132
+  fpus_per_core: 128
+  block_dim_limit_x: 2147483647
+  block_dim_limit_y: 65535
+  block_dim_limit_z: 65535
+  memory_bandwidth: 3352320000000
+  l2_cache_size: 52428800
+  clock_rate_ghz: 1.98
+  device_memory_size: 84929347584
+  shared_memory_per_block_optin: 232448
+  cuda_compute_capability {
+    major: 9
+  }
+  registers_per_core_limit: 65536
+  registers_per_block_limit: 65536
+}
+runtime_version: {
+  major: 12
+  minor: 8
+  patch: 0
+}
+platform_name: "CUDA"
+dnn_version_info {
+  major: 9
+  minor: 7
+}
+device_description_str: "NVIDIA H100 80GB HBM3"
+"""
+
+
+def test_vmap_fwd_tensor_product_multi_devices():
+    """Real jax.vmap + sharding: leading vmap axis is split across 2 devices,
+    and the custom_vmap rule flattens (axis_size, num_rows) into a single
+    batch dim seen by the ffi.
+    """
+    num_out, idx, val, x, y = generate_tp_data()
+    coef = pack_coef(val, idx)
+    params = Params(num_out=num_out, mode="OUTER")
+
+    topology = get_topology_desc(
+        "name",
+        "cuda",
+        target_config=h100_gpu_target_config,
+        topology="1x1x2",
+    )
+    mesh = jax.sharding.Mesh(topology.devices, axis_names=["batch"])
+    sharding = jax.sharding.NamedSharding(
+        mesh=mesh,
+        spec=jax.sharding.PartitionSpec("batch", None, None),
+    )
+
+    def tp(x, y):
+        return tensor_product(coef, x, y, params)
+
+    tp_jitted = jax.jit(
+        jax.vmap(tp),
+        in_shardings=(sharding, sharding),
+        out_shardings=sharding,
+    )
+    tp_compiled = tp_jitted.lower(
+        jax.core.ShapedArray((128, *x.shape), x.dtype),
+        jax.core.ShapedArray((128, *y.shape), y.dtype),
+    ).compile()
+    tp_compiled_string = tp_compiled.as_text()
+
+    # What we expect to see in the HLO on each shard:
+    #   - The vmapped batch dimension (size 128) is sharded over 2 devices,
+    #     so each shard handles 64 samples. vmap then folds those into the
+    #     kernel's own row axis (NUM_ROWS=128), giving 64 * 128 = 8192 rows
+    #     fed into the forward kernel.
+    #   - Exactly one `tensor_product` custom call per shard, with inputs
+    #     (coef, x, y) and output z; coef is replicated across shards.
+    #
+    # Dimension legend (also referenced by the backward test below):
+    #   8192  = rows_per_shard = 64 (sharded vmap) * NUM_ROWS (128)
+    #   20    = x.shape[-1] = out.shape[-1] (from generate_tp_data)
+    #   30    = y.shape[-1] (from generate_tp_data)
+    #   60    = #non-zeros in coef = NUM_STRIPS (10) * LEN_STRIPS (6)
+    #   4     = packed Coef entry (1 value + 3 index components)
+    regex = re.compile(
+        r"= f32\[8192,20\]\{1,0\}.+"  # output: z
+        r'custom_call_target="tensor_product".+'
+        r"operand_layout_constraints=\{"
+        r"s32\[60,4\]\{1,0\}, "  # coef
+        r"f32\[8192,20\]\{1,0\}, "  # x
+        r"f32\[8192,30\]\{1,0\}\}",  # y
+        flags=re.MULTILINE,
+    )
+    assert len(list(regex.finditer(tp_compiled_string))) == 1, (
+        f"Expected exactly one tensor_product custom call, found "
+        f"{len(list(regex.finditer(tp_compiled_string)))}.\n\n"
+        f"HLO:\n{tp_compiled_string}"
+    )
+
+
+def test_vmap_grad_tensor_product_multi_devices():
+    """Check that the operation is sharded as expected when vmapped and jitted over 2 device.
+    This test use precompilation so it does not require a GPU to run but need to have jax version
+    with gpu support.
+
+    TODO: generalize this setup so we can use it for other tests and run them in the CI.
+    """
+    num_out, idx, val, x, y = generate_tp_data(channels=(128, None))
+    coef = pack_coef(val, idx)
+
+    # Use TRAILING_CHANNELS so the VJP routes through the tensor_product_bwd
+    params = Params(num_out=num_out, mode="OUTER", layout="TRAILING_CHANNELS")
+    x_shape = (x.shape[0], x.shape[2], x.shape[1])
+
+    topology = get_topology_desc(
+        "name",
+        "cuda",
+        target_config=h100_gpu_target_config,
+        topology="1x1x2",
+    )
+    mesh = jax.sharding.Mesh(topology.devices, axis_names=["batch"])
+    sharding = jax.sharding.NamedSharding(
+        mesh=mesh,
+        spec=jax.sharding.PartitionSpec("batch", None, None),
+    )
+    y_sharding = jax.sharding.NamedSharding(
+        mesh=mesh,
+        spec=jax.sharding.PartitionSpec("batch", None),
+    )
+
+    def tp(x, y):
+        return tensor_product(coef, x, y, params)
+
+    def sum_vmap_tp(x, y):
+        return np.sum(jax.vmap(tp)(x, y))
+
+    # A function with forward + backward tensor product passes
+    fn = jax.grad(sum_vmap_tp, argnums=(0, 1))
+
+    jitted_fn = jax.jit(
+        fn,
+        in_shardings=(sharding, y_sharding),
+        out_shardings=(sharding, y_sharding),
+    )
+    compiled_fn = jitted_fn.lower(
+        jax.core.ShapedArray((128, *x_shape), x.dtype),
+        jax.core.ShapedArray((128, *y.shape), y.dtype),
+    ).compile()  # Check that it compiles without error
+
+    compiled_fn_string = compiled_fn.as_text()
+
+    # Same shard / batch reasoning as the forward test
+    # (`test_vmap_fwd_tensor_product_multi_devices`); see the dimension
+    # legend there for 8192, 20, 30, 60, 4. Extras that only appear in the
+    # backward HLO:
+    #   128 = x channels (TRAILING_CHANNELS layout); y has no channel dim
+    #   2   = the two transposed COO orderings stacked in coef_bwd (xzy, yzx)
+    #
+    # Exactly one `tensor_product_bwd` custom call per shard, with inputs
+    # (coef_bwd, x, y, ct_z) and outputs (ct_x, ct_y).
+    regex = re.compile(
+        # outputs: (ct_x, ct_y)
+        r"\(f32\[8192,20,128\]\{2,1,0\}, f32\[8192,30\]\{1,0\}\) custom-call.+"
+        r'custom_call_target="tensor_product_bwd".+'
+        r"operand_layout_constraints=\{"
+        r"s32\[2,60,4\]\{2,1,0\}, "  # coef_bwd
+        r"f32\[8192,20,128\]\{2,1,0\}, "  # x
+        r"f32\[8192,30\]\{1,0\}, "  # y
+        r"f32\[8192,20,128\]\{2,1,0\}\}",  # ct_z
+        flags=re.MULTILINE,
+    )
+    assert len(list(regex.finditer(compiled_fn_string))) == 1, (
+        f"Expected exactly one tensor_product_bwd custom call, found "
+        f"{len(list(regex.finditer(compiled_fn_string)))}.\n\n"
+        f"HLO:\n{compiled_fn_string}"
+    )
+
+
+def test_vmap_raises_on_batched_coef():
+    num_out, idx, val, x, y = generate_tp_data()
+    coef = pack_coef(val, idx)
+    params = Params(num_out=num_out, mode="OUTER")
+    coef_batch = np.stack([coef, coef, coef])
+    with pytest.raises(jax.errors.UnexpectedTracerError):
+        jax.vmap(lambda c: tensor_product(c, x, y, params))(coef_batch)
+
+
+def test_vmap_batches_on_x_only():
+    num_out, idx, val, x, y = generate_tp_data()
+    coef = pack_coef(val, idx)
+    params = Params(num_out=num_out, mode="OUTER")
+    xs = np.stack([x, x, x])
+    zs = jax.vmap(lambda xi: tensor_product(coef, xi, y, params))(xs)
+    assert zs.shape[0] == xs.shape[0]
+    testing.assert_allclose(zs[0], zs[-1])
+
+
+def test_vmap_batches_on_y_only():
+    num_out, idx, val, x, y = generate_tp_data()
+    coef = pack_coef(val, idx)
+    params = Params(num_out=num_out, mode="OUTER")
+    ys = np.stack([y, y, y])
+    zs = jax.vmap(lambda yi: tensor_product(coef, x, yi, params))(ys)
+    assert zs.shape[0] == ys.shape[0]
+    testing.assert_allclose(zs[0], zs[-1])
+
+
+def test_backward_tensor_product():
+    """Check backward pass on x and y gradients."""
+    num_out, idx, val, x, y = generate_tp_data()
+    params = Params(num_out=num_out, mode="OUTER")
+    coef = pack_coef(val, idx)
+
+    def f_custom(x, y):
+        return np.sum(tensor_product(coef, x, y, params))
+
+    def f_ref(x, y):
+        return np.sum(tensor_product_reference(idx, val, x, y, num_out=num_out))
+
+    grads_custom = jax.grad(f_custom, argnums=(0, 1))(x, y)
+    grads_ref = jax.grad(f_ref, argnums=(0, 1))(x, y)
+
+    ct_x, ct_y = grads_custom
+    ct_x_ref, ct_y_ref = grads_ref
+    assert np.allclose(ct_x, ct_x_ref)
+    assert np.allclose(ct_y, ct_y_ref)
+
+
+def test_backward2_tensor_product():
+    """Check two TP backward passes on x and y."""
+    num_out, idx, val, x, y = generate_tp_data()
+    params = Params(num_out=num_out, mode="OUTER")
+    coef = pack_coef(val, idx)
+
+    def prod_custom(x, y):
+        return np.sum(tensor_product(coef, x, y, params))
+
+    def prod_ref(x, y):
+        return np.sum(tensor_product_reference(idx, val, x, y, num_out=num_out))
+
+    def force_grads(prod: callable) -> callable:
+        force_norm_x = lambda x, y: np.sum((jax.grad(prod)(x, y)) ** 2)
+        return jax.grad(force_norm_x, argnums=(0, 1))
+
+    d2x, d2y = force_grads(prod_custom)(x, y)
+    d2x_ref, d2y_ref = force_grads(prod_ref)(x, y)
+
+    assert np.allclose(d2x, d2x_ref)
+    assert np.allclose(d2y, d2y_ref)

--- a/tests/test_ops/test_tensor_product_op.py
+++ b/tests/test_ops/test_tensor_product_op.py
@@ -12,15 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
-
 import jax
 import jax.numpy as np
 import jax.random as random
 import numpy.testing as testing
 import pytest
 from jax import Array
-from jax.experimental.topologies import get_topology_desc
 
 import e3j
 from e3j.ops import TensorProductParams as Params
@@ -32,10 +29,20 @@ e3j.config(
     debug_level=0,
 )
 
-NUM_STRIPS = 10
-LEN_STRIPS = 6
-NUM_ROWS = 128
-NUM_CHANNELS = 32
+
+@pytest.fixture(scope="class", params=[32, 64, 128, 512])
+def channels(request):
+    request.cls.channels_x = request.param
+    if getattr(request.cls, "mode", None) in ("INNER", "MAP"):
+        request.cls.channels_y = request.param
+    elif getattr(request.cls, "mode", None) == "OUTER":
+        request.cls.channels_y = None
+
+
+@pytest.fixture(scope="class", params=["OUTER", "INNER", "MAP"])
+def mode(request):
+    request.cls.mode = request.param
+
 
 np.set_printoptions(
     precision=4,
@@ -63,42 +70,6 @@ def assert_allclose(expect, result, rtol=5e-6, atol=5e-6, debug: int = 1):
         raise err
 
 
-def generate_tp_data(
-    channels: tuple[int | None, int | None] = (None, None),
-) -> tuple[int, Array, Array, Array, Array]:
-    """
-    Generate common test inputs for the forward and backward tests.
-
-    Returns:
-        num_out: target space dimension.
-        idx: A 2D index array of leading dimension 3.
-        coef: A 1D value vector of length `idx.shape[-1]`.
-        x: A 2D array of shape `(..., num_x)`
-        y: A 2D array of shape `(..., num_y)`
-    """
-    num_rows = NUM_ROWS
-
-    # lexsorted indices
-    num_out, num_x, num_y = 2, 2, 3
-    idx_0 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
-    idx_1 = np.tile(np.array([0, 0, 0, 1, 1, 1]), NUM_STRIPS)
-    idx_2 = np.tile(np.array([0, 1, 2, 0, 1, 2]), NUM_STRIPS)
-    offsets = np.array([num_out, num_x, num_y])[:, None]
-    offsets *= np.arange(NUM_STRIPS).repeat(LEN_STRIPS)
-    idx = np.stack([idx_0, idx_1, idx_2]) + offsets
-
-    x = np.stack([np.tile(np.array([1.0, 2.0]), NUM_STRIPS)] * num_rows)
-    y = np.stack([np.tile(np.array([3.0, 4.0, 5.0]), NUM_STRIPS)] * num_rows)
-
-    if channels[0] is not None:
-        x = np.tile(x[:, None, :], (1, channels[0], 1))
-    if channels[1] is not None:
-        y = np.tile(y[:, None, :], (1, channels[1], 1))
-
-    coef = np.ones(idx.shape[-1])
-    return num_out * NUM_STRIPS, idx, coef, x, y
-
-
 def tensor_product_reference(
     idx, coef, x, y, num_out, mode="OUTER", layout="LEADING_CHANNELS"
 ):
@@ -115,6 +86,10 @@ def tensor_product_reference(
     n_rows = x.shape[0]
 
     if mode == "MAP":
+        assert (
+            x.ndim == 3 and y.ndim == 3
+        ), "MAP mode requires channel dims on both x and y"
+        assert x.shape[1] == y.shape[1], "MAP mode requires channels_x == channels_y"
         shape_out = (n_rows, x.shape[1], num_out)
         out = np.zeros(shape_out, dtype=x.dtype)
         cxy = coef * x[..., idx[1]] * y[..., idx[2]]
@@ -139,7 +114,10 @@ def tensor_product_reference(
         return out.at[..., idx[0]].add(cxy)
 
     if mode == "INNER":
-        assert x.shape[-2] == y.shape[-2]
+        assert (
+            x.ndim == 3 and y.ndim == 3
+        ), "INNER mode requires channel dims on both x and y"
+        assert x.shape[1] == y.shape[1], "INNER mode requires channels_x == channels_y"
         shape_out = (n_rows, num_out)
         out = np.zeros(shape_out, dtype=x.dtype)
         cxy = coef * x[..., idx[1]] * y[..., idx[2]]
@@ -147,321 +125,16 @@ def tensor_product_reference(
         return out.at[..., idx[0]].add(sum_cxy)
 
 
-def test_forward_tensor_product():
-    """Check forward pass."""
-    num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, mode="OUTER")
-    expect = tensor_product_reference(idx, val, x, y, num_out)
-    result = tensor_product(pack_coef(val, idx), x, y, params)
-    assert np.allclose(expect, result, atol=1e-5)
-
-
-def test_forward_tensor_product_inner():
-    """Check forward pass."""
-    num_out, idx, val, x, y = generate_tp_data(channels=[NUM_CHANNELS] * 2)
-    params = Params(num_out=num_out, mode="INNER")
-    expect = tensor_product_reference(idx, val, x, y, num_out, mode="INNER")
-    result = tensor_product(pack_coef(val, idx), x, y, params)
-    assert np.allclose(expect, result, atol=1e-5)
-
-
-def test_jit_tensor_product():
-    """Check that e3j.ops.tensor_product can be compiled."""
-    num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, mode="OUTER")
-    coef = pack_coef(val, idx)
-
-    @jax.jit
-    def tp(x, y, num_out):
-        return tensor_product(coef, x, y, params)
-
-    assert tp(x, y, num_out).shape[-1] == num_out
-
-
-def test_jit_tensor_product_vmap():
-    """Check that e3j.ops.tensor_product can be compiled."""
-    num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, mode="OUTER")
-    coef = pack_coef(val, idx)
-    xs = np.stack([x, x])
-    ys = np.stack([y, y])
-
-    def tp(x, y):
-        return tensor_product(coef, x, y, params)
-
-    out_normal = tp(x, y)
-    out_vmap = jax.vmap(tp)(xs, ys)
-    assert out_normal.shape[-1] == num_out
-    assert out_vmap.shape[-1] == num_out
-    assert out_vmap[0].shape == out_normal.shape
-    assert np.allclose(out_vmap[0], out_normal, atol=1e-5)
-    assert np.allclose(out_vmap[1], out_normal, atol=1e-5)
-
-
-# Target config to simulate H100 GPU for testing
-h100_gpu_target_config = """
-gpu_device_info {
-  threads_per_block_limit: 1024
-  threads_per_warp: 32
-  shared_memory_per_block: 49152
-  shared_memory_per_core: 233472
-  threads_per_core_limit: 2048
-  core_count: 132
-  fpus_per_core: 128
-  block_dim_limit_x: 2147483647
-  block_dim_limit_y: 65535
-  block_dim_limit_z: 65535
-  memory_bandwidth: 3352320000000
-  l2_cache_size: 52428800
-  clock_rate_ghz: 1.98
-  device_memory_size: 84929347584
-  shared_memory_per_block_optin: 232448
-  cuda_compute_capability {
-    major: 9
-  }
-  registers_per_core_limit: 65536
-  registers_per_block_limit: 65536
-}
-runtime_version: {
-  major: 12
-  minor: 8
-  patch: 0
-}
-platform_name: "CUDA"
-dnn_version_info {
-  major: 9
-  minor: 7
-}
-device_description_str: "NVIDIA H100 80GB HBM3"
-"""
-
-
-def test_vmap_fwd_tensor_product_multi_devices():
-    """Real jax.vmap + sharding: leading vmap axis is split across 2 devices,
-    and the custom_vmap rule flattens (axis_size, num_rows) into a single
-    batch dim seen by the ffi.
-    """
-    num_out, idx, val, x, y = generate_tp_data()
-    coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, mode="OUTER")
-
-    topology = get_topology_desc(
-        "name",
-        "cuda",
-        target_config=h100_gpu_target_config,
-        topology="1x1x2",
-    )
-    mesh = jax.sharding.Mesh(topology.devices, axis_names=["batch"])
-    sharding = jax.sharding.NamedSharding(
-        mesh=mesh,
-        spec=jax.sharding.PartitionSpec("batch", None, None),
-    )
-
-    def tp(x, y):
-        return tensor_product(coef, x, y, params)
-
-    tp_jitted = jax.jit(
-        jax.vmap(tp),
-        in_shardings=(sharding, sharding),
-        out_shardings=sharding,
-    )
-    tp_compiled = tp_jitted.lower(
-        jax.core.ShapedArray((128, *x.shape), x.dtype),
-        jax.core.ShapedArray((128, *y.shape), y.dtype),
-    ).compile()
-    tp_compiled_string = tp_compiled.as_text()
-
-    # What we expect to see in the HLO on each shard:
-    #   - The vmapped batch dimension (size 128) is sharded over 2 devices,
-    #     so each shard handles 64 samples. vmap then folds those into the
-    #     kernel's own row axis (NUM_ROWS=128), giving 64 * 128 = 8192 rows
-    #     fed into the forward kernel.
-    #   - Exactly one `tensor_product` custom call per shard, with inputs
-    #     (coef, x, y) and output z; coef is replicated across shards.
-    #
-    # Dimension legend (also referenced by the backward test below):
-    #   8192  = rows_per_shard = 64 (sharded vmap) * NUM_ROWS (128)
-    #   20    = x.shape[-1] = out.shape[-1] (from generate_tp_data)
-    #   30    = y.shape[-1] (from generate_tp_data)
-    #   60    = #non-zeros in coef = NUM_STRIPS (10) * LEN_STRIPS (6)
-    #   4     = packed Coef entry (1 value + 3 index components)
-    regex = re.compile(
-        r"= f32\[8192,20\]\{1,0\}.+"  # output: z
-        r'custom_call_target="tensor_product".+'
-        r"operand_layout_constraints=\{"
-        r"s32\[60,4\]\{1,0\}, "  # coef
-        r"f32\[8192,20\]\{1,0\}, "  # x
-        r"f32\[8192,30\]\{1,0\}\}",  # y
-        flags=re.MULTILINE,
-    )
-    assert len(list(regex.finditer(tp_compiled_string))) == 1, (
-        f"Expected exactly one tensor_product custom call, found "
-        f"{len(list(regex.finditer(tp_compiled_string)))}.\n\n"
-        f"HLO:\n{tp_compiled_string}"
-    )
-
-
-def test_vmap_grad_tensor_product_multi_devices():
-    """Check that the operation is sharded as expected when vmapped and jitted over 2 device.
-    This test use precompilation so it does not require a GPU to run but need to have jax version
-    with gpu support.
-
-    TODO: generalize this setup so we can use it for other tests and run them in the CI.
-    """
-    num_out, idx, val, x, y = generate_tp_data(channels=(128, None))
-    coef = pack_coef(val, idx)
-
-    # Use TRAILING_CHANNELS so the VJP routes through the tensor_product_bwd
-    params = Params(num_out=num_out, mode="OUTER", layout="TRAILING_CHANNELS")
-    x_shape = (x.shape[0], x.shape[2], x.shape[1])
-
-    topology = get_topology_desc(
-        "name",
-        "cuda",
-        target_config=h100_gpu_target_config,
-        topology="1x1x2",
-    )
-    mesh = jax.sharding.Mesh(topology.devices, axis_names=["batch"])
-    sharding = jax.sharding.NamedSharding(
-        mesh=mesh,
-        spec=jax.sharding.PartitionSpec("batch", None, None),
-    )
-    y_sharding = jax.sharding.NamedSharding(
-        mesh=mesh,
-        spec=jax.sharding.PartitionSpec("batch", None),
-    )
-
-    def tp(x, y):
-        return tensor_product(coef, x, y, params)
-
-    def sum_vmap_tp(x, y):
-        return np.sum(jax.vmap(tp)(x, y))
-
-    # A function with forward + backward tensor product passes
-    fn = jax.grad(sum_vmap_tp, argnums=(0, 1))
-
-    jitted_fn = jax.jit(
-        fn,
-        in_shardings=(sharding, y_sharding),
-        out_shardings=(sharding, y_sharding),
-    )
-    compiled_fn = jitted_fn.lower(
-        jax.core.ShapedArray((128, *x_shape), x.dtype),
-        jax.core.ShapedArray((128, *y.shape), y.dtype),
-    ).compile()  # Check that it compiles without error
-
-    compiled_fn_string = compiled_fn.as_text()
-
-    # Same shard / batch reasoning as the forward test
-    # (`test_vmap_fwd_tensor_product_multi_devices`); see the dimension
-    # legend there for 8192, 20, 30, 60, 4. Extras that only appear in the
-    # backward HLO:
-    #   128 = x channels (TRAILING_CHANNELS layout); y has no channel dim
-    #   2   = the two transposed COO orderings stacked in coef_bwd (xzy, yzx)
-    #
-    # Exactly one `tensor_product_bwd` custom call per shard, with inputs
-    # (coef_bwd, x, y, ct_z) and outputs (ct_x, ct_y).
-    regex = re.compile(
-        # outputs: (ct_x, ct_y)
-        r"\(f32\[8192,20,128\]\{2,1,0\}, f32\[8192,30\]\{1,0\}\) custom-call.+"
-        r'custom_call_target="tensor_product_bwd".+'
-        r"operand_layout_constraints=\{"
-        r"s32\[2,60,4\]\{2,1,0\}, "  # coef_bwd
-        r"f32\[8192,20,128\]\{2,1,0\}, "  # x
-        r"f32\[8192,30\]\{1,0\}, "  # y
-        r"f32\[8192,20,128\]\{2,1,0\}\}",  # ct_z
-        flags=re.MULTILINE,
-    )
-    assert len(list(regex.finditer(compiled_fn_string))) == 1, (
-        f"Expected exactly one tensor_product_bwd custom call, found "
-        f"{len(list(regex.finditer(compiled_fn_string)))}.\n\n"
-        f"HLO:\n{compiled_fn_string}"
-    )
-
-
-def test_vmap_raises_on_batched_coef():
-    num_out, idx, val, x, y = generate_tp_data()
-    coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, mode="OUTER")
-    coef_batch = np.stack([coef, coef, coef])
-    with pytest.raises(jax.errors.UnexpectedTracerError):
-        jax.vmap(lambda c: tensor_product(c, x, y, params))(coef_batch)
-
-
-def test_vmap_batches_on_x_only():
-    num_out, idx, val, x, y = generate_tp_data()
-    coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, mode="OUTER")
-    xs = np.stack([x, x, x])
-    zs = jax.vmap(lambda xi: tensor_product(coef, xi, y, params))(xs)
-    assert zs.shape[0] == xs.shape[0]
-    testing.assert_allclose(zs[0], zs[-1])
-
-
-def test_vmap_batches_on_y_only():
-    num_out, idx, val, x, y = generate_tp_data()
-    coef = pack_coef(val, idx)
-    params = Params(num_out=num_out, mode="OUTER")
-    ys = np.stack([y, y, y])
-    zs = jax.vmap(lambda yi: tensor_product(coef, x, yi, params))(ys)
-    assert zs.shape[0] == ys.shape[0]
-    testing.assert_allclose(zs[0], zs[-1])
-
-
-def test_backward_tensor_product():
-    """Check backward pass on x and y gradients."""
-    num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, mode="OUTER")
-    coef = pack_coef(val, idx)
-
-    def f_custom(x, y):
-        return np.sum(tensor_product(coef, x, y, params))
-
-    def f_ref(x, y):
-        return np.sum(tensor_product_reference(idx, val, x, y, num_out=num_out))
-
-    grads_custom = jax.grad(f_custom, argnums=(0, 1))(x, y)
-    grads_ref = jax.grad(f_ref, argnums=(0, 1))(x, y)
-
-    ct_x, ct_y = grads_custom
-    ct_x_ref, ct_y_ref = grads_ref
-    assert np.allclose(ct_x, ct_x_ref)
-    assert np.allclose(ct_y, ct_y_ref)
-
-
-def test_backward2_tensor_product():
-    """Check two TP backward passes on x and y."""
-    num_out, idx, val, x, y = generate_tp_data()
-    params = Params(num_out=num_out, mode="OUTER")
-    coef = pack_coef(val, idx)
-
-    def prod_custom(x, y):
-        return np.sum(tensor_product(coef, x, y, params))
-
-    def prod_ref(x, y):
-        return np.sum(tensor_product_reference(idx, val, x, y, num_out=num_out))
-
-    def force_grads(prod: callable) -> callable:
-        force_norm_x = lambda x, y: np.sum((jax.grad(prod)(x, y)) ** 2)
-        return jax.grad(force_norm_x, argnums=(0, 1))
-
-    d2x, d2y = force_grads(prod_custom)(x, y)
-    d2x_ref, d2y_ref = force_grads(prod_ref)(x, y)
-
-    assert np.allclose(d2x, d2x_ref)
-    assert np.allclose(d2y, d2y_ref)
-
-
 class _TestTensorProductOp:
     mode: str
-    num_idx: int
-    num_x: int
-    num_y: int
+    num_idx: int = 530
+    num_x: int = 42
+    num_y: int = 25
     num_out: int
     channels_x: int | None = None
     channels_y: int | None = None
-    num_rows = 16
-    layout: str = "LEADING_CHANNELS"
+    num_rows = 100
+    layout: str = "TRAILING_CHANNELS"
 
     def closure(self):
         """Return coefficient buffers and tensor product descriptor.
@@ -585,105 +258,107 @@ class _TestTensorProductOp:
         x, y = self.inputs()
         expect = self.fwd_ref(x, y)
         result = self.fwd_op(x, y)
-        assert_allclose(expect, result, rtol=1e-5, atol=1e-5)
+        assert_allclose(expect, result, atol=5e-5, rtol=5e-5)
 
     def test_backward(self):
         x, y = self.inputs()
         expect_dx, expect_dy = self.bwd_ref(x, y)
         result_dx, result_dy = self.bwd_op(x, y)
-        assert_allclose(expect_dx, result_dx, atol=5e-5, rtol=5e-5)
-        assert_allclose(expect_dy, result_dy, atol=5e-5, rtol=5e-5)
+        assert_allclose(expect_dx, result_dx, atol=1e-4, rtol=2e-3)
+        assert_allclose(expect_dy, result_dy, atol=1e-4, rtol=2e-3)
 
     def test_backward_backward(self):
         x, y = self.inputs()
         dz = self.fwd_ref(x, y)
         expect_Dx, expect_Dy, expect_Ddz = self.bwd_bwd_ref(x, y, dz)
         result_Dx, result_Dy, result_Ddz = self.bwd_bwd_op(x, y, dz)
-        assert_allclose(expect_Dx, result_Dx, atol=5e-5, rtol=5e-5)
-        assert_allclose(expect_Dy, result_Dy, atol=5e-5, rtol=5e-5)
-        assert_allclose(expect_Ddz, result_Ddz, atol=5e-5, rtol=5e-5)
+        assert_allclose(expect_Dx, result_Dx, atol=1e-4, rtol=2e-3)
+        assert_allclose(expect_Dy, result_Dy, atol=1e-4, rtol=2e-3)
+        assert_allclose(expect_Ddz, result_Ddz, atol=1e-4, rtol=2e-3)
 
 
+@pytest.mark.usefixtures("channels")
 class TestTensorProductOuter(_TestTensorProductOp):
+    layout = "TRAILING_CHANNELS"
     mode = "OUTER"
-    num_idx = 530
     num_x = 16
     num_y = 25
-    num_out = 12
-    channels_x = 8
-    channels_y = None
-    num_rows = 6
+    num_out = 93
+    num_rows = 100
 
 
+@pytest.mark.usefixtures("channels")
 class TestTensorProductInner(_TestTensorProductOp):
+    layout = "TRAILING_CHANNELS"
     mode = "INNER"
-    num_idx = 535
-    num_x = 12
-    num_y = 43
-    num_out = 31
-    channels_x = 4
-    channels_y = 4
-    num_rows = 12
+    num_x = 16
+    num_y = 25
+    num_out = 93
+    num_rows = 100
 
 
-class TestTensorProductOuterTrailing(TestTensorProductOuter):
+@pytest.mark.usefixtures("channels")
+class TestTensorProductMap(_TestTensorProductOp):
     layout = "TRAILING_CHANNELS"
-    # FIXME: seems to require num_channels multiple of 32
-    channels_x = 32
-    channels_y = None
-    num_rows = 22
-    num_idx = 320
+    mode = "MAP"
+    num_x = 16
+    num_y = 25
+    num_out = 93
+    num_rows = 100
 
 
-class TestTensorProductOuterTrailingCY(TestTensorProductOuterTrailing):
-    layout = "TRAILING_CHANNELS"
-    channels_x = 32
-    channels_y = None
-    num_rows = 22
-    num_idx = 320
-
-
-class TestTensorProductInnerTrailing(TestTensorProductInner):
-    layout = "TRAILING_CHANNELS"
-    channels_x = 32
-    channels_y = 32
-
-
-class TestTensorProductOuterOneIn(TestTensorProductOuter):
+@pytest.mark.usefixtures("channels")
+class TestTensorProductOuterOneIn(_TestTensorProductOp):
     layout = "TRAILING_CHANNELS"
     mode = "OUTER"
-    channels_x = 32
-    channels_y = None
     num_x = 16
     num_y = 1
     num_out = 16
     num_idx = 30
-    num_rows = 2
+    num_rows = 64
 
 
-class TestTensorProductInnerOneOut(TestTensorProductInner):
+class TestTensorProductInnerOneOut(_TestTensorProductOp):
     layout = "TRAILING_CHANNELS"
     mode = "INNER"
-    channels_x = 32
-    channels_y = 32
-    num_x = 16
-    num_y = 16
+    num_x = 25
+    num_y = 25
+    channels_x = 512
+    channels_y = 512
     num_out = 1
-    num_idx = 28
-    num_rows = 2
+    num_idx = 42
+    num_rows = 8
 
 
-class TestTensorProductMapTrailing(_TestTensorProductOp):
+class TestTensorProductOuterCY(_TestTensorProductOp):
     layout = "TRAILING_CHANNELS"
-    mode = "MAP"
-    channels_x = 32
-    channels_y = 32
+    mode = "OUTER"
+    channels_x = None
+    channels_y = 128
+    num_rows = 22
+    num_idx = 512
+    num_out = 210
+
+
+class TestTensorProductLeadingOuter(_TestTensorProductOp):
+    layout = "LEADING_CHANNELS"
+    mode = "OUTER"
+    num_idx = 780
     num_x = 16
-    num_y = 18
-    num_out = 12
-    num_idx = 132
-    num_rows = 4
+    num_y = 25
+    channels_x = 256
+    channels_y = None
+    num_out = 93
+    num_rows = 100
 
 
-if __name__ == "__main__":
-    num_out, idx, coef, x, y = generate_tp_data()
+class TestTensorProductLeadingInner(_TestTensorProductOp):
+    layout = "LEADING_CHANNELS"
+    mode = "INNER"
+    num_idx = 780
+    num_x = 16
+    num_y = 25
+    channels_x = 256
+    channels_y = 256
+    num_out = 93
+    num_rows = 100

--- a/tests/test_ops/test_zero_gap_rows.py
+++ b/tests/test_ops/test_zero_gap_rows.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2026 InstaDeep Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for _zero_gap_rows correctness in tensor_product backward.
+
+The irrep combination used here has real CG gap rows:
+
+    '4x0e + 6x1o + 3x1e + 7x2e + 4x2o + 6x3o + 4x3e'
+      x  '1x0e + 1x1o + 1x2e + 1x3o'  ->  23x0e
+
+x's 1e (9 coords), 2o (20 coords), and 3e (28 coords) irreps cannot couple
+to any y irrep to produce 0e output, leaving 57 gap rows in ct_x that
+_zero_gap_rows must zero explicitly.  If missing or broken, those rows
+contain uninitialized memory (NaN) and the gradient diverges from reference.
+"""
+
+import jax
+import jax.numpy as np
+import jax.random as random
+import numpy.testing as testing
+
+import e3j
+from e3j.core.tensor_product import TensorProduct as CoreTP
+from e3j.ops import TensorProductParams as Params
+from e3j.ops import tensor_product
+from e3j.ops.coef import Coef
+
+e3j.config(debug_level=0)
+
+IN1 = "4x0e + 6x1o + 3x1e + 7x2e + 4x2o + 6x3o + 4x3e"
+IN2 = "1x0e + 1x1o + 1x2e + 1x3o"
+
+
+def pack_coef(val, idx, val_dtype="float32", idx_dtype="int32"):
+    return Coef(val, idx.T, val_dtype=val_dtype, idx_dtype=idx_dtype).pack_jax()
+
+
+def assert_allclose(expect, result, rtol=5e-6, atol=5e-6, debug: int = 1):
+    try:
+        testing.assert_allclose(expect, result, rtol=rtol, atol=atol)
+    except AssertionError as err:
+        if debug >= 1:
+            print("expect == result\n", abs(expect - result) < atol)
+        raise err
+
+
+def tensor_product_reference(
+    idx, coef, x, y, num_out, mode="OUTER", layout="TRAILING_CHANNELS"
+):
+    """Reference tensor_product (pure scatter-add; naturally zeros gap rows)."""
+    if layout == "TRAILING_CHANNELS":
+        x_t = x if x.ndim < 3 else np.matrix_transpose(x)
+        y_t = y if y.ndim < 3 else np.matrix_transpose(y)
+        z_t = tensor_product_reference(idx, coef, x_t, y_t, num_out, mode)
+        return z_t if z_t.ndim < 3 else np.matrix_transpose(z_t)
+
+    n_rows = x.shape[0]
+    if mode == "MAP":
+        out = np.zeros((n_rows, x.shape[1], num_out), dtype=x.dtype)
+        return out.at[..., idx[0]].add(coef * x[..., idx[1]] * y[..., idx[2]])
+    if mode == "OUTER":
+        has_cx, has_cy = x.ndim > 2, y.ndim > 2
+        if not (has_cx or has_cy):
+            out = np.zeros((n_rows, num_out), dtype=x.dtype)
+        elif has_cx:
+            out = np.zeros((n_rows, x.shape[1], num_out), dtype=x.dtype)
+            y = y[:, None]
+        else:
+            out = np.zeros((n_rows, y.shape[1], num_out), dtype=x.dtype)
+            x = x[:, None]
+        return out.at[..., idx[0]].add(coef * x[..., idx[1]] * y[..., idx[2]])
+
+
+class _TestGapRows:
+    """Backward correctness for a tensor product with real CG gap rows.
+
+    Subclasses set ``mode``, ``channels_x``, and ``channels_y``.
+    ``closure()`` returns the same ``(idx, val, kwargs)`` triple as
+    ``_TestTensorProductOp.closure()``, but built from actual CG coefficients
+    so that gap rows exist and _zero_gap_rows is exercised.
+    """
+
+    mode: str
+    layout: str = "TRAILING_CHANNELS"
+    channels_x: int | None = None
+    channels_y: int | None = None
+    num_rows: int = 16
+    num_x: int = 156
+    num_y: int = 16
+    num_out: int = 23
+
+    def closure(self):
+        with e3j.config.use(tensor_product="FUSED"):
+            tp = CoreTP((IN1, IN2), "0e", sort=True, layout=self.layout, mode=self.mode)
+        coef = tp.coef
+        idx = np.array(coef.indices).T  # (3, nnz)
+        val = coef.data
+        kwargs = {"num_out": tp.target.dim, "mode": self.mode, "layout": self.layout}
+        return idx, val, kwargs
+
+    @property
+    def fwd_ref(self):
+        idx, val, kwargs = self.closure()
+        return lambda x, y: tensor_product_reference(idx, val, x, y, **kwargs)
+
+    @property
+    def fwd_op(self):
+        idx, val, kwargs = self.closure()
+        coef = pack_coef(val, idx)
+        params = Params(**kwargs)
+        return lambda x, y: tensor_product(coef, x, y, params)
+
+    @property
+    def bwd_ref(self):
+        return jax.grad(
+            lambda x, y: np.sum(self.fwd_ref(x, y)),
+            argnums=(0, 1),
+        )
+
+    @property
+    def bwd_op(self):
+        return jax.grad(
+            lambda x, y: np.sum(self.fwd_op(x, y)),
+            argnums=(0, 1),
+        )
+
+    def inputs(self):
+        n = self.num_rows
+        nx, ny = self.num_x, self.num_y
+        cx, cy = self.channels_x, self.channels_y
+        shape_x = (n, nx) if cx is None else (n, nx, cx)
+        shape_y = (n, ny) if cy is None else (n, ny, cy)
+        keys = (k for k in random.split(random.key(123), 2))
+        x = random.normal(next(keys), shape_x)
+        y = random.normal(next(keys), shape_y)
+        return x, y
+
+    def test_backward(self):
+        x, y = self.inputs()
+        expect_dx, expect_dy = self.bwd_ref(x, y)
+        result_dx, result_dy = self.bwd_op(x, y)
+        assert_allclose(expect_dx, result_dx, atol=1e-4, rtol=2e-3)
+        assert_allclose(expect_dy, result_dy, atol=1e-4, rtol=2e-3)
+
+
+class TestGapRowsOUTER(_TestGapRows):
+    layout = "TRAILING_CHANNELS"
+    mode = "OUTER"
+    channels_x = 32
+    channels_y = None
+
+
+class TestGapRowsMAP(_TestGapRows):
+    layout = "TRAILING_CHANNELS"
+    mode = "MAP"
+    channels_x = 32
+    channels_y = 32

--- a/tests/test_ops/test_zero_gap_rows.py
+++ b/tests/test_ops/test_zero_gap_rows.py
@@ -56,7 +56,7 @@ def assert_allclose(expect, result, rtol=5e-6, atol=5e-6, debug: int = 1):
 
 
 def tensor_product_reference(
-    idx, coef, x, y, num_out, mode="OUTER", layout="TRAILING_CHANNELS"
+    idx, coef, x, y, num_out, mode="OUTER", layout="LEADING_CHANNELS"
 ):
     """Reference tensor_product (pure scatter-add; naturally zeros gap rows)."""
     if layout == "TRAILING_CHANNELS":
@@ -139,8 +139,12 @@ class _TestGapRows:
         n = self.num_rows
         nx, ny = self.num_x, self.num_y
         cx, cy = self.channels_x, self.channels_y
-        shape_x = (n, nx) if cx is None else (n, nx, cx)
-        shape_y = (n, ny) if cy is None else (n, ny, cy)
+        if self.layout == "LEADING_CHANNELS":
+            shape_x = (n, nx) if cx is None else (n, cx, nx)
+            shape_y = (n, ny) if cy is None else (n, cy, ny)
+        else:
+            shape_x = (n, nx) if cx is None else (n, nx, cx)
+            shape_y = (n, ny) if cy is None else (n, ny, cy)
         keys = (k for k in random.split(random.key(123), 2))
         x = random.normal(next(keys), shape_x)
         y = random.normal(next(keys), shape_y)
@@ -166,3 +170,10 @@ class TestGapRowsMAP(_TestGapRows):
     mode = "MAP"
     channels_x = 32
     channels_y = 32
+
+
+class TestGapRowsOUTERLeading(_TestGapRows):
+    layout = "LEADING_CHANNELS"
+    mode = "OUTER"
+    channels_x = 32
+    channels_y = None

--- a/uv.lock
+++ b/uv.lock
@@ -872,7 +872,7 @@ wheels = [
 
 [[package]]
 name = "e3j"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "e3nn-jax" },
@@ -1040,7 +1040,7 @@ tensorboard = [
 
 [[package]]
 name = "e3j-ops"
-version = "0.1.0b2"
+version = "0.1.0b3"
 source = { editable = "lib/e3j_ops" }
 
 [[package]]


### PR DESCRIPTION
## [0.1.0b3] — 2026-06-10

### Fixed

- Fused tensor product backward (`tensor_product_bwd()`) left gradient rows for
  uncoupled input coordinates uninitialized (garbage / NaN) instead of zero. The
  kernel only writes coordinates present in the Clebsch-Gordan coefficients, so
  coordinates absent from them — common when the forward output is truncated,
  e.g. symmetric contraction in MAP mode — were never written, diverging from the
  SPARSE/DENSE autodiff gradients. Those rows are now zeroed explicitly after the
  kernel.

### Changed

- Tensor product forward and backward CUDA kernels now share a single
  `CuArray2D.load()` / `.store()` abstraction for global↔shared memory copies,
  replacing the per-operand branching between contiguous and strided variants.
  Loads use LDGSTS (asynchronous copy via pipeline primitives) and stride through
  source channels automatically when they exceed the shared-memory budget.